### PR TITLE
songs.py: Allow links with <> to be matched

### DIFF
--- a/cogs/monitors/misc/songs.py
+++ b/cogs/monitors/misc/songs.py
@@ -30,10 +30,11 @@ class Songs(commands.Cog):
         self.bot = bot
         # self.spotify_pattern = re.compile(r"[\bhttps://open.\b]spotify[\b.com\b]*[/:]*track[/:]*[A-Za-z0-9]+")
         # self.am_pattern = re.compile(r"[\bhttps://music.\b]apple[\b.com\b]*[/:][[a-zA-Z][a-zA-Z]]?[:/]album[/:][a-zA-Z\d%\(\)-]+[/:][\d]{1,10}")
-        self.pattern = re.compile(
-            r"(https://open.spotify.com/track/[A-Za-z0-9]+|https://music.apple.com/[[a-zA-Z][a-zA-Z]]?/album/[a-zA-Z\d%\(\)-]+/[\d]{1,10}\?i=[\d]{1,15})")
-        self.song_phrases = ["I like listening to {artist} too!\nHere's \"{title}\"...",
-                             "You listen to {artist} too? They're my favorite!\nHere's \"{title}\"..."]
+        self.pattern = re.compile(r"https:\/\/(open.spotify.com\/track\/[A-Za-z0-9]+|music.apple.com\/[a-zA-Z][a-zA-Z]?\/album\/[a-zA-Z\d%\(\)-]+/[\d]{1,10}\?i=[\d]{1,15})")
+        self.song_phrases = [
+            "I Like listening to {artist} too!\n Here's \"{title}\"...",
+            "You listen to {artist} too? They're my favorite!\nHere's \"{title}\"..."
+        ]
 
     @commands.Cog.listener()
     async def on_message(self, message: discord.Message):
@@ -48,7 +49,7 @@ class Songs(commands.Cog):
         if message.channel.id != guild_service.get_guild().channel_general:
             return
 
-        match = self.pattern.search(message.content)
+        match = self.pattern.search(message.content.strip("<>"))
         if match:
             link = match.group(0)
             await self.generate_view(message, link)


### PR DESCRIPTION
This PR allows ports a commit I (accidentally) made to Bloo, which allows for links containing <> to be still be detected by the regex expression used in the songs cog.

This allows users to skip embedding a link while still allowing Bloo to give information about the song link sent.