### PR TITLE
Add /unclem command

### DIFF
--- a/cogs/commands/mod/modutils.py
+++ b/cogs/commands/mod/modutils.py
@@ -333,7 +333,7 @@ class ModUtils(commands.Cog):
             embed.add_field(name=f"{len(rd)} most recent cases",
                             value=rd_text, inline=False)
         else:
-            embed.add_field(name=f"Recent cases",
+            embed.add_field(name="Recent cases",
                             value="This user has no cases.", inline=False)
 
         return embed

--- a/utils/views/autocompleters.py
+++ b/utils/views/autocompleters.py
@@ -254,6 +254,15 @@ async def warn_autocomplete(interaction: discord.Interaction, current: str) -> L
 
     return [app_commands.Choice(name=f"{case._id} - {case.punishment} points - {case.reason}", value=str(case._id)) for case in cases if (not current or str(case._id).startswith(str(current)))][:25]
 
+async def clem_autocomplete(interaction: discord.Interaction, current: str) -> List[app_commands.Choice[str]]:
+    if not gatekeeper.has(interaction.guild, interaction.user, 5):
+        return []
+
+    cases: List[Case] = [case for case in user_service.get_cases(
+        int(interaction.namespace["member"].id)).cases if case._type == "CLEM" and not case.lifted]
+    cases.sort(key=lambda x: x._id, reverse=True)
+
+    return [app_commands.Choice(name=f"{case._id} - {case.date.strptime('%I:%M%p %b %o, %Y')}", value=str(case._id)) for case in cases if (not current or str(case._id).startswith(str(current)))][:25]
 
 async def timezone_autocomplete(_: discord.Interaction, current: str) -> List[app_commands.Choice[str]]:
     return [app_commands.Choice(name=tz, value=tz) for tz in pytz.common_timezones_set if current.lower() in tz.lower() or current.lower() in tz.replace("_", " ").lower()][:25]


### PR DESCRIPTION
This adds the `/unclem` command, since `/clem` isn't un-doable currently.

I'm still iffy on whether generating XP for all messages sent post-clem should be done or not, mainly due to it being resource-intensive given the amount of messages the bot would be sorting through in a server like r/Jailbreak, so that can be removed if needed.

Also, I'm not entirely familiar with Gir's codebase, so this definitely needs to be properly test before merging (not sure if i'm missing anything, I mostly used other commands as references).

~~@aaronp613 unclem me thx~~