### PR TITLE
Add portable community, safety, and utility suites

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,4 +34,10 @@ RESNEXT_TOKEN="your token here"
 
 # optional
 # enable /memegen text and /memegen aipfp commands
-# ENABLE_MARKOV=True 
+# ENABLE_MARKOV=True
+
+# Optional community-suite configuration. Defaults are shown below.
+# GIR_SYNC_COMMANDS=True
+# GIR_COMMUNITY_FILE=data/community.json
+# GIR_FEATURE_FILE=data/features.json
+# TSSCHECKER_PATH=/path/to/tsschecker

--- a/.gitignore
+++ b/.gitignore
@@ -125,6 +125,7 @@ dmypy.json
 
 # macOS files
 .DS_Store
+._*
 
 # PyCharm files
 .idea/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # GIR Rewrite
+
 ![GIR banner](data/images/banner.png)
 
 GIR is a sophisticated moderation and miscellaneous utilities Discord bot created for the [r/Jailbreak Discord server](https://reddit.com/r/jailbreak). It features:
@@ -51,7 +52,7 @@ This setup uses Docker for deployment. You will need the following:
 
 If everything is successful, the bot should be online in a few seconds. Otherwise, check the container's logs: `docker-compose logs gir`.
 
-> **IMPORTANT**: slash commands are not synced automatically. Instead, the bot owner can DM the bot `!sync` to sync slash commands with Discord. This only needs to be done once when the bot is set up, or when you change any of the command data (such adding a new command, changing a command's name or description, etc.) 
+> Slash commands synchronize to the configured guild when GIR starts. Set `GIR_SYNC_COMMANDS=False` if an operator needs to manage synchronization manually with `!sync`.
 
 The bot can be updated in the future by running: `git pull && docker-compose up -d --build --force-recreate`
 
@@ -109,6 +110,28 @@ If you want to inspect or change database values:
 - If running MongoDB in Docker, you can use the web GUI at http://127.0.0.1:8081
 
 ---
+
+
+## Optional community suite setup
+
+This change adds general community, free-game, expression, Apple signing, and moderation tools. They use the existing dependencies in `requirements.txt`; no paid API key is required.
+
+- `GIR_COMMUNITY_FILE` can point to a JSON settings file. It defaults to `data/community.json`, which is created from safe defaults.
+- `GIR_FEATURE_FILE` can point to a JSON file containing an `enabled` array of extension names. When it is unset, all upstream extensions and both new suites load normally.
+- `GIR_SYNC_COMMANDS=False` disables automatic guild command synchronization. It is enabled by default.
+- `TSSCHECKER_PATH` is optional. Interactive TSS commands use IPSW.me's small firmware catalog and do not download IPSW files.
+- Configure the existing `member_plus`, `moderator`, and `administrator` role IDs and the `reports` channel ID during normal database setup. Users below Member+ who post four images in one message receive a seven-day timeout and a staff review card.
+- The bot needs **Manage Messages**, **Moderate Members**, **Ban Members**, **Manage Roles**, **Manage Expressions**, and **View Audit Log** for the corresponding features. Its role must sit above members it moderates. Enable the Server Members and Message Content privileged intents in the Discord Developer Portal.
+
+Free-game checks use the keyless GamerPower, Epic Games Store, and CheapShark endpoints. Optional background actions remain disabled in `data/community.json` until configured.
+
+### Data services and attribution
+
+- [GamerPower](https://www.gamerpower.com/) supplies public giveaway listings and is linked from every applicable result.
+- [Epic Games Store](https://store.epicgames.com/free-games) supplies its first-party promotion catalog.
+- [CheapShark](https://www.cheapshark.com/) supplies public PC-store deal data.
+- [IPSW.me](https://ipsw.me/) supplies Apple device and signing-status metadata.
+- [FreeStuff](https://github.com/FreeStuffBot/FreeStuff) was reviewed as a product reference for filtering and presentation. This implementation is independent and does not include its GPL-licensed source.
 
 ## Contributors
 

--- a/cogs/commands/misc/misc.py
+++ b/cogs/commands/misc/misc.py
@@ -141,11 +141,28 @@ class Misc(commands.Cog):
             await give_user_birthday_role(self.bot, ctx.author, ctx.guild)
 
     @app_commands.guilds(cfg.guild_id)
-    @app_commands.command(description="Get avatar of another user or yourself.")
-    @app_commands.describe(user="The user you want to get the avatar of")
+    @app_commands.command(description="Get a Discord user's profile picture.")
+    @app_commands.describe(
+        user="A member or user Discord can suggest",
+        discord_id="A numeric Discord user ID, including someone outside this server",
+    )
     @transform_context
     @whisper
-    async def avatar(self, ctx: GIRContext, user: Union[discord.Member, discord.User] = None) -> None:
+    async def avatar(
+        self,
+        ctx: GIRContext,
+        user: Union[discord.Member, discord.User] = None,
+        discord_id: str = None,
+    ) -> None:
+        if user is not None and discord_id is not None:
+            raise commands.BadArgument("Choose a user or enter a Discord ID, not both.")
+        if discord_id is not None:
+            if not discord_id.isdigit():
+                raise commands.BadArgument("Enter a numeric Discord user ID.")
+            try:
+                user = await self.bot.fetch_user(int(discord_id))
+            except (discord.NotFound, discord.HTTPException):
+                raise commands.BadArgument("I could not find that Discord user.")
         if user is None:
             user = ctx.author
 

--- a/cogs/commands/mod/modactions.py
+++ b/cogs/commands/mod/modactions.py
@@ -60,25 +60,6 @@ class ModActions(commands.Cog):
 
     @mod_and_up()
     @app_commands.guilds(cfg.guild_id)
-    @app_commands.command(description="Kick a user")
-    @app_commands.describe(member="User to kick")
-    @transform_context
-    async def roblox(self, ctx: GIRContext, member: ModsAndAboveMember) -> None:
-        reason = "This Discord server is for iOS jailbreaking, not Roblox. Please join https://discord.gg/jailbreak instead, thank you!"
-
-        db_guild = guild_service.get_guild()
-
-        log = add_kick_case(target_member=member, mod=ctx.author, reason=reason, db_guild=db_guild)
-        await notify_user(member, f"You were kicked from {ctx.guild.name}", log)
-
-        await ctx.defer(ephemeral=False)
-        await member.kick(reason=reason)
-
-        await ctx.respond_or_edit(embed=log, delete_after=10)
-        await submit_public_log(ctx, member, log)
-
-    @mod_and_up()
-    @app_commands.guilds(cfg.guild_id)
     @app_commands.command(description="Mute a user")
     @app_commands.describe(member="User to mute")
     @app_commands.describe(duration="Duration of the mute (i.e 10m, 1h, 1d...)")
@@ -424,7 +405,7 @@ class ModActions(commands.Cog):
 
     @mod_and_up()
     @app_commands.guilds(cfg.guild_id)
-    @app_commands.command(description="Edit case reason")
+    @app_commands.command(description="Remove warning points from a member")
     @app_commands.describe(member="Member to remove points from")
     @app_commands.describe(points="Amount of points to remove")
     @app_commands.describe(reason="Reason for removing points")

--- a/cogs/community_suite.py
+++ b/cogs/community_suite.py
@@ -1,0 +1,1006 @@
+"""Modern community management tools inspired by popular general-purpose bots.
+
+The module is intentionally configured through GIR's private dashboard.  Safety
+actions start disabled, and every automatic action can be reviewed in Discord.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import random
+import re
+import zipfile
+from io import BytesIO
+import time
+from urllib.parse import quote
+from collections import defaultdict, deque
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import discord
+import aiohttp
+from discord import app_commands
+from discord.ext import commands, tasks
+
+from utils import cfg, logger
+from utils.framework.permissions import gatekeeper
+from community_rules import caps_percent, has_invite, is_image_attachment, recent_count
+
+
+DATA_FILE = Path(os.environ.get(
+    "GIR_COMMUNITY_FILE",
+    str(Path("data/community.json")),
+))
+GAME_STATE_FILE = DATA_FILE.with_name("free-games-state.json")
+GAME_STATUS_FILE = DATA_FILE.with_name("free-games-status.json")
+GAME_REQUEST_FILE = DATA_FILE.with_name("free-games-request.json")
+GAME_API = "https://www.gamerpower.com/api/giveaways"
+EPIC_API = "https://store-site-backend-static.ak.epicgames.com/freeGamesPromotions?locale=en-US&country=US&allowCountries=US"
+CHEAPSHARK_API = "https://www.cheapshark.com/api/1.0/deals?onSale=1&pageSize=60&sortBy=Savings"
+
+DEFAULTS = {
+    "automod": {
+        "enabled": False, "reportChannelID": 0, "deleteMessage": True,
+        "timeoutHours": 168, "imageSpam": True, "imageThreshold": 4,
+        "imageWindowSeconds": 20, "fastSpam": True, "messageThreshold": 7,
+        "messageWindowSeconds": 8, "capsSpam": True, "capsPercent": 80,
+        "mentionSpam": True, "mentionThreshold": 6, "inviteLinks": False,
+        "monitorAllChannels": True, "monitoredChannelIDs": [], "ignoredChannelIDs": [], "ignoredRoleIDs": [],
+    },
+    "welcome": {"enabled": False, "channelID": 0, "message": "Welcome {mention} to {server}!", "goodbyeEnabled": False, "goodbyeMessage": "{name} left the server."},
+    "autorole": {"enabled": False, "roleIDs": []},
+    "starboard": {"enabled": False, "channelID": 0, "threshold": 3, "emoji": "⭐"},
+    "suggestions": {"enabled": False, "channelID": 0},
+    "freeGames": {"enabled": False, "channelID": 0, "platforms": ["pc", "steam", "epic-games-store", "ps4", "ps5", "xbox-one", "xbox-series-xs"], "types": ["game"], "sources": ["gamerpower", "epic", "cheapshark"], "offerMode": "both", "minimumDiscountPercent": 50, "checkMinutes": 15, "pingRoleID": 0, "minimumWorth": 0, "hideUnrated": False, "includeExpired": False, "maxPostsPerCheck": 5},
+    "movieNight": {"enabled": False, "channelID": 0, "pingRoleID": 0},
+    "relay": {"enabled": False, "destinationGuildID": 0, "messages": True, "edits": True,
+              "deletes": True, "reactions": True, "channelRoutes": []},
+    "customCommands": [], "autoResponses": [], "reactionRoles": [], "disabledCommands": [],
+}
+
+_SETTINGS_CACHE = None
+_SETTINGS_MTIME = None
+
+
+def _merge(base, incoming):
+    result = dict(base)
+    for key, value in incoming.items():
+        result[key] = _merge(result[key], value) if isinstance(result.get(key), dict) and isinstance(value, dict) else value
+    return result
+
+
+def load_settings():
+    global _SETTINGS_CACHE, _SETTINGS_MTIME
+    try:
+        modified = DATA_FILE.stat().st_mtime_ns
+        if _SETTINGS_CACHE is None or modified != _SETTINGS_MTIME:
+            _SETTINGS_CACHE = _merge(DEFAULTS, json.loads(DATA_FILE.read_text()))
+            _SETTINGS_MTIME = modified
+        return _SETTINGS_CACHE
+    except (OSError, ValueError, TypeError):
+        if _SETTINGS_CACHE is None:
+            _SETTINGS_CACHE = _merge(DEFAULTS, {})
+        return _SETTINGS_CACHE
+
+
+def render(template: str, member: discord.Member) -> str:
+    return template.replace("{mention}", member.mention).replace("{name}", member.display_name).replace("{server}", member.guild.name)
+
+
+class CommunitySuite(commands.Cog):
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+        self.activity = defaultdict(lambda: deque(maxlen=30))
+        self.images = defaultdict(lambda: deque(maxlen=30))
+        self.star_posts = {}
+        self.afk = {}
+        self.relay_queue = asyncio.Queue(maxsize=10000)
+        self.game_provider_health = {}
+        self.game_check_lock = asyncio.Lock()
+        self.relay_worker = asyncio.create_task(self._relay_worker())
+        self.free_game_check.start()
+        self.free_game_request_check.start()
+
+    def cog_unload(self):
+        self.free_game_check.cancel()
+        self.free_game_request_check.cancel()
+        self.relay_worker.cancel()
+
+    def settings(self):
+        return load_settings()
+
+    def _queue_relay(self, event: str, channel_id: int, payload: dict):
+        relay = self.settings().get("relay", {})
+        event_flag = {"message": "messages", "edit": "edits", "delete": "deletes", "reaction": "reactions"}[event]
+        if not relay.get("enabled") or not relay.get(event_flag):
+            return
+        route = next((item for item in relay.get("channelRoutes", [])
+                      if int(item.get("sourceChannelID", 0)) == channel_id), None)
+        if not route:
+            return
+        payload.update({"event": event, "destinationChannelID": int(route.get("destinationChannelID", 0))})
+        try:
+            self.relay_queue.put_nowait(payload)
+        except asyncio.QueueFull:
+            logger.error("Audit relay queue is full; newest event was dropped")
+
+    async def _relay_worker(self):
+        while True:
+            item = await self.relay_queue.get()
+            try:
+                destination = self.bot.get_channel(item["destinationChannelID"])
+                if not isinstance(destination, discord.TextChannel):
+                    continue
+                colors = {"message": discord.Color.blurple(), "edit": discord.Color.orange(),
+                          "delete": discord.Color.red(), "reaction": discord.Color.green()}
+                titles = {"message": "Message", "edit": "Message edited", "delete": "Message deleted", "reaction": "Reaction"}
+                embed = discord.Embed(title=titles[item["event"]], description=str(item.get("content") or "No text")[:3500],
+                                      color=colors[item["event"]], timestamp=datetime.now(timezone.utc))
+                embed.add_field(name="Member", value=f"{item.get('author', 'Unknown')} · `{item.get('authorID', 'Unknown')}`", inline=False)
+                embed.add_field(name="Source", value=f"#{item.get('channel', 'unknown')} · `{item.get('channelID')}`", inline=True)
+                if item.get("detail"):
+                    embed.add_field(name="Details", value=str(item["detail"])[:1024], inline=True)
+                if item.get("jumpURL"):
+                    embed.add_field(name="Original", value=f"[Open message]({item['jumpURL']})", inline=False)
+                attachments = item.get("attachments", [])
+                if attachments:
+                    embed.add_field(name="Attachments", value="\n".join(attachments)[:1024], inline=False)
+                await destination.send(embed=embed, allowed_mentions=discord.AllowedMentions.none())
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("Could not relay Discord audit event")
+            finally:
+                self.relay_queue.task_done()
+
+    async def _fetch_json(self, session, name, url):
+        try:
+            async with session.get(url, timeout=aiohttp.ClientTimeout(total=20)) as response:
+                if response.status == 201:
+                    return name, []
+                response.raise_for_status()
+                return name, await response.json(content_type=None)
+        except (aiohttp.ClientError, asyncio.TimeoutError, ValueError) as error:
+            logger.warning("Free-game provider %s failed: %s", name, error)
+            return name, error
+
+    @staticmethod
+    def _epic_games(payload):
+        rows = payload.get("data", {}).get("Catalog", {}).get("searchStore", {}).get("elements", [])
+        games = []
+        for row in rows:
+            promotions = (row.get("promotions") or {}).get("promotionalOffers") or []
+            offers = [offer for block in promotions for offer in block.get("promotionalOffers", [])]
+            free = next((offer for offer in offers if offer.get("discountSetting", {}).get("discountPercentage") == 0), None)
+            if not free:
+                continue
+            images = row.get("keyImages") or []
+            image = next((item.get("url") for item in images if item.get("type") in {"OfferImageWide", "DieselStoreFrontWide"}), None)
+            slug = row.get("productSlug") or row.get("urlSlug") or ""
+            price = row.get("price", {}).get("totalPrice", {}).get("fmtPrice", {}).get("originalPrice") or "Unknown"
+            games.append({"id": f"epic:{row.get('id')}", "title": row.get("title"), "description": row.get("description"),
+                          "platforms": "PC, Epic Games Store", "type": "game", "worth": price,
+                          "end_date": free.get("endDate"), "image": image,
+                          "open_giveaway_url": f"https://store.epicgames.com/p/{slug}" if slug else "https://store.epicgames.com/free-games",
+                          "source": "Epic Games Store", "source_url": "https://store.epicgames.com/free-games"})
+        return games
+
+    @staticmethod
+    def _cheapshark_games(rows):
+        return [{"id": f"cheapshark:{row.get('dealID')}", "title": row.get("title"), "description": f"Discounted from ${float(row.get('normalPrice') or 0):.2f} to ${float(row.get('salePrice') or 0):.2f}.",
+                 "platforms": "PC", "type": "game", "worth": f"${float(row.get('normalPrice') or 0):.2f}",
+                 "salePrice": float(row.get("salePrice") or 0), "discountPercent": float(row.get("savings") or 0),
+                 "end_date": None, "thumbnail": row.get("thumb"),
+                 "open_giveaway_url": f"https://www.cheapshark.com/redirect?dealID={quote(str(row.get('dealID') or ''), safe='')}",
+                 "source": "CheapShark", "source_url": "https://www.cheapshark.com/"}
+                for row in rows]
+
+    @staticmethod
+    def _dedupe_games(games):
+        unique = {}
+        for game in games:
+            key = re.sub(r"[^a-z0-9]", "", str(game.get("title", "")).lower())
+            if key and key not in unique:
+                unique[key] = game
+        return list(unique.values())
+
+    @staticmethod
+    def _game_date(value):
+        if not value:
+            return None
+        try:
+            return datetime.fromisoformat(str(value).replace("Z", "+00:00")).astimezone(timezone.utc)
+        except ValueError:
+            try:
+                return datetime.strptime(str(value), "%Y-%m-%d %H:%M:%S").replace(tzinfo=timezone.utc)
+            except ValueError:
+                return None
+
+    async def fetch_free_games(self, settings=None):
+        settings = settings or {}
+        enabled = set(settings.get("sources") or ["gamerpower", "epic", "cheapshark"])
+        urls = {"gamerpower": GAME_API + "?sort-by=date", "epic": EPIC_API, "cheapshark": CHEAPSHARK_API}
+        async with aiohttp.ClientSession(headers={"User-Agent": "GIR Discord Bot/1.0"}) as session:
+            results = await asyncio.gather(*(self._fetch_json(session, name, url) for name, url in urls.items() if name in enabled))
+        games = []
+        for name, payload in results:
+            if isinstance(payload, Exception):
+                self.game_provider_health[name] = "Unavailable"
+                continue
+            self.game_provider_health[name] = f"OK · {len(payload.get('data', {}).get('Catalog', {}).get('searchStore', {}).get('elements', [])) if name == 'epic' else len(payload)} records"
+            if name == "gamerpower":
+                # Preserve GamerPower's historical IDs so upgrades do not repost every active offer.
+                games.extend({**item, "id": str(item.get("id")), "source": "GamerPower", "source_url": "https://www.gamerpower.com/"} for item in payload)
+            elif name == "epic":
+                games.extend(self._epic_games(payload))
+            elif name == "cheapshark":
+                games.extend(self._cheapshark_games(payload))
+        return self._dedupe_games(games)
+
+    def filtered_games(self, games, settings):
+        platforms = {str(value).lower() for value in settings.get("platforms", [])}
+        types = {str(value).lower() for value in settings.get("types", [])}
+        minimum_worth = max(0.0, float(settings.get("minimumWorth", 0) or 0))
+        now = datetime.now(timezone.utc)
+        offer_mode = str(settings.get("offerMode", "both")); minimum_discount = float(settings.get("minimumDiscountPercent", 50) or 0)
+
+        def worth(game):
+            match = re.search(r"\d+(?:\.\d+)?", str(game.get("worth") or "0").replace(",", ""))
+            return float(match.group()) if match else 0.0
+
+        def active(game):
+            if settings.get("includeExpired") or not game.get("end_date"):
+                return True
+            end = self._game_date(game["end_date"])
+            return end is None or end > now
+
+        def offer_matches(game):
+            source = str(game.get("source", "")).lower()
+            text = " ".join(str(game.get(key, "")) for key in ("title", "description")).lower()
+            free = game.get("salePrice") == 0 or source in {"gamerpower", "epic games store"} or bool(re.search(r"\b(free|giveaway)\b|\$0\.00|100% off", text))
+            discounted = float(game.get("discountPercent") or 0) >= minimum_discount
+            return free if offer_mode == "free" else discounted and not free if offer_mode == "discounts" else free or discounted
+
+        aliases = {"epic-games-store": "epic games store", "ps4": "playstation 4", "ps5": "playstation 5",
+                   "xbox-one": "xbox one", "xbox-series-xs": "xbox series x/s", "itchio": "itch.io"}
+
+        def platform_matches(game):
+            offered = {part.strip().lower() for part in str(game.get("platforms", "")).split(",")}
+            return not platforms or any((value == "pc" and "pc" in offered) or aliases.get(value, value) in offered for value in platforms)
+
+        return [game for game in games
+                if platform_matches(game)
+                and (not types or str(game.get("type", "")).lower() in types)
+                and worth(game) >= minimum_worth
+                and (not settings.get("hideUnrated") or worth(game) > 0)
+                and offer_matches(game)
+                and active(game)]
+
+    @tasks.loop(minutes=15)
+    async def free_game_check(self):
+        settings = self.settings()["freeGames"]
+        minutes = min(1440, max(5, int(settings.get("checkMinutes", 15) or 15)))
+        if self.free_game_check.minutes != minutes:
+            self.free_game_check.change_interval(minutes=minutes)
+        await self.run_free_game_check(settings)
+
+    def _save_game_status(self, state, **details):
+        now = datetime.now(timezone.utc)
+        payload = {"state": state, "updatedAt": int(now.timestamp()), "providerHealth": self.game_provider_health, **details}
+        GAME_STATUS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        temporary = GAME_STATUS_FILE.with_suffix(".tmp")
+        temporary.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+        temporary.replace(GAME_STATUS_FILE)
+        return payload
+
+    async def run_free_game_check(self, settings=None, *, manual=False):
+        settings = settings or self.settings()["freeGames"]
+        if not settings.get("enabled"):
+            return self._save_game_status("disabled", message="Automatic free-game alerts are off")
+        if self.game_check_lock.locked():
+            return self._save_game_status("busy", message="A free-game check is already running")
+        minutes = min(1440, max(5, int(settings.get("checkMinutes", 15) or 15)))
+        channel = self.bot.get_channel(int(settings.get("channelID") or 0))
+        if not channel:
+            preferred = ("free-games", "freebies", "game-deals", "giveaways")
+            guild = self.bot.get_guild(cfg.guild_id)
+            by_name = {item.name.lower(): item for item in getattr(guild, "text_channels", [])}
+            channel = next((by_name[name] for name in preferred if name in by_name), None)
+            if channel:
+                try:
+                    saved = json.loads(DATA_FILE.read_text())
+                    saved.setdefault("freeGames", {})["channelID"] = channel.id
+                    temporary = DATA_FILE.with_suffix(".tmp")
+                    temporary.write_text(json.dumps(saved, indent=2, sort_keys=True) + "\n")
+                    temporary.replace(DATA_FILE)
+                except (OSError, ValueError, TypeError):
+                    logger.exception("Could not persist the recovered free-game channel")
+        if not channel:
+            logger.warning("Free-game alerts are enabled but no valid alert channel is available")
+            return self._save_game_status("failed", message="No valid free-game channel is available")
+        async with self.game_check_lock:
+            started = datetime.now(timezone.utc)
+            self._save_game_status("checking", startedAt=int(started.timestamp()), channelID=channel.id)
+            try:
+                games = self.filtered_games(await self.fetch_free_games(settings), settings)
+                try:
+                    saved = json.loads(GAME_STATE_FILE.read_text())
+                    seen = set(saved.get("seen", [])); history = list(saved.get("history", []))
+                except (OSError, ValueError, TypeError):
+                    seen = {str(game.get("id")) for game in games}; history = []
+                unseen = [item for item in games if str(item.get("id")) not in seen]
+                post_limit = min(20, max(1, int(settings.get("maxPostsPerCheck", 5) or 5)))
+                posted = []
+                for game in reversed(unseen[:post_limit]):
+                    await self.post_game(channel, game, settings)
+                    record = {"id": str(game.get("id")), "title": str(game.get("title", "Free game"))[:256],
+                              "source": str(game.get("source", "Unknown")), "channelID": channel.id,
+                              "postedAt": int(datetime.now(timezone.utc).timestamp())}
+                    posted.append(record); history.insert(0, record)
+                seen.update(str(game.get("id")) for game in games)
+                GAME_STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+                temporary = GAME_STATE_FILE.with_suffix(".tmp")
+                temporary.write_text(json.dumps({"seen": sorted(seen)[-4000:], "history": history[:250]}, indent=2) + "\n")
+                temporary.replace(GAME_STATE_FILE)
+                finished = datetime.now(timezone.utc)
+                return self._save_game_status("complete", startedAt=int(started.timestamp()), lastCheck=int(finished.timestamp()),
+                    nextCheck=int(finished.timestamp()) + minutes * 60, durationMs=int((finished - started).total_seconds() * 1000),
+                    channelID=channel.id, offersFound=len(games), newOffers=len(unseen), posted=len(posted), manual=manual)
+            except Exception as error:
+                logger.exception("Free game check failed")
+                return self._save_game_status("failed", startedAt=int(started.timestamp()), lastCheck=int(time.time()),
+                                              channelID=channel.id, message=str(error)[:300], manual=manual)
+
+    @free_game_check.before_loop
+    async def before_free_game_check(self):
+        await self.bot.wait_until_ready()
+
+    @tasks.loop(seconds=10)
+    async def free_game_request_check(self):
+        try:
+            request = json.loads(GAME_REQUEST_FILE.read_text())
+        except (OSError, ValueError, TypeError):
+            return
+        if request.get("state") != "requested":
+            return
+        request["state"] = "working"; request["startedAt"] = int(time.time())
+        temporary = GAME_REQUEST_FILE.with_suffix(".tmp")
+        temporary.write_text(json.dumps(request, indent=2) + "\n"); temporary.replace(GAME_REQUEST_FILE)
+        result = await self.run_free_game_check(manual=True)
+        request.update({"state": "complete" if result.get("state") == "complete" else result.get("state", "failed"),
+                        "finishedAt": int(time.time()), "result": result})
+        temporary.write_text(json.dumps(request, indent=2) + "\n"); temporary.replace(GAME_REQUEST_FILE)
+
+    @free_game_request_check.before_loop
+    async def before_free_game_request_check(self):
+        await self.bot.wait_until_ready()
+
+    @staticmethod
+    def _game_platform(game):
+        platforms = str(game.get("platforms", "")).lower()
+        choices = (("steam", "Steam", "https://store.steampowered.com/search/?term="),
+                   ("epic", "Epic Games Store", "https://store.epicgames.com/browse?q="),
+                   ("gog", "GOG", "https://www.gog.com/en/games?query="),
+                   ("xbox", "Xbox", "https://www.xbox.com/search/results?q="),
+                   ("playstation", "PlayStation", "https://store.playstation.com/search/"),
+                   ("switch", "Nintendo Switch", "https://www.nintendo.com/us/search/#q="),
+                   ("itch", "itch.io", "https://itch.io/search?q="))
+        for needle, label, search in choices:
+            if needle in platforms:
+                return label, search + quote(str(game.get("title", "")))
+        return "PC and console", None
+
+    @staticmethod
+    def _claim_kind(game):
+        if game.get("salePrice") is not None and float(game.get("salePrice") or 0) > 0:
+            return f"{float(game.get('discountPercent') or 0):.0f}% off"
+        text = " ".join(str(game.get(key, "")) for key in ("title", "description", "instructions")).lower()
+        temporary = ("free weekend", "free week", "free to play until", "play for free", "open beta", "playtest")
+        return "Free to play" if any(phrase in text for phrase in temporary) else "Free to keep"
+
+    @staticmethod
+    def game_embed(game):
+        title = str(game.get("title", "Free game"))[:256]
+        url = game.get("open_giveaway_url") or game.get("gamerpower_url") or "https://www.gamerpower.com/"
+        end_time = CommunitySuite._game_date(game.get("end_date"))
+        until = f" until {discord.utils.format_dt(end_time, 'd')}" if end_time else " while available"
+        claim_kind = CommunitySuite._claim_kind(game)
+        platform, _ = CommunitySuite._game_platform(game)
+        description = f"**{claim_kind}**{until}\n\n{str(game.get('description', '')).strip()[:700]}".strip()
+        embed = discord.Embed(title=title, url=url, description=description, color=discord.Color.from_rgb(88, 101, 242))
+        embed.set_author(name=platform)
+        if game.get("image") or game.get("thumbnail"):
+            embed.set_image(url=game.get("image") or game.get("thumbnail"))
+        source = str(game.get("source") or "Giveaway source")
+        worth = str(game.get("worth") or "").strip()
+        sale_price = game.get("salePrice")
+        users = int(game.get("users") or 0)
+        footer = f"via {source}"
+        if worth and worth.lower() != "unknown":
+            footer += f" · Usually {worth}"
+        if sale_price is not None and float(sale_price or 0) > 0:
+            footer += f" · Now ${float(sale_price):.2f}"
+        if users:
+            footer += f" · {users:,} claimed"
+        embed.set_footer(text=footer[:2048])
+        return embed
+
+    @staticmethod
+    def game_view(game):
+        browser_url = str(game.get("open_giveaway_url") or game.get("gamerpower_url") or game.get("source_url") or "https://www.gamerpower.com/")
+        platform, store_url = CommunitySuite._game_platform(game)
+        view = discord.ui.View(timeout=None)
+        view.add_item(discord.ui.Button(label="Open in browser ↗", style=discord.ButtonStyle.link, url=browser_url[:512]))
+        if store_url and store_url != browser_url:
+            view.add_item(discord.ui.Button(label=f"Open in {platform} ↗"[:80], style=discord.ButtonStyle.link, url=store_url[:512]))
+        return view
+
+    async def post_game(self, channel, game, settings):
+        embed = self.game_embed(game)
+        role_id = int(settings.get("pingRoleID") or 0); role = channel.guild.get_role(role_id)
+        mentions = discord.AllowedMentions(roles=[role] if role else False, users=False, everyone=False)
+        await channel.send(content=role.mention if role else None, embed=embed, view=self.game_view(game), allowed_mentions=mentions)
+
+    @staticmethod
+    def _staff(member: discord.Member, settings: dict) -> bool:
+        ignored = set(settings.get("ignoredRoleIDs", []))
+        return member.guild_permissions.manage_messages or any(role.id in ignored for role in member.roles)
+
+    @commands.Cog.listener()
+    async def on_member_join(self, member: discord.Member):
+        settings = self.settings()
+        auto = settings["autorole"]
+        if auto.get("enabled"):
+            roles = [member.guild.get_role(int(role_id)) for role_id in auto.get("roleIDs", [])]
+            roles = [role for role in roles if role and role < member.guild.me.top_role]
+            if roles:
+                try:
+                    await member.add_roles(*roles, reason="GIR automatic member role")
+                except discord.HTTPException:
+                    logger.exception("Could not assign automatic roles")
+        welcome = settings["welcome"]
+        if welcome.get("enabled"):
+            channel = member.guild.get_channel(int(welcome.get("channelID") or 0))
+            if channel:
+                await channel.send(render(str(welcome.get("message", "")), member), allowed_mentions=discord.AllowedMentions(users=True))
+
+    @commands.Cog.listener()
+    async def on_member_remove(self, member: discord.Member):
+        welcome = self.settings()["welcome"]
+        if welcome.get("goodbyeEnabled"):
+            channel = member.guild.get_channel(int(welcome.get("channelID") or 0))
+            if channel:
+                await channel.send(render(str(welcome.get("goodbyeMessage", "")), member))
+
+    @commands.Cog.listener()
+    async def on_message(self, message: discord.Message):
+        if not message.guild or message.author.bot or message.guild.id != cfg.guild_id:
+            return
+        self._queue_relay("message", message.channel.id, {"author": str(message.author), "authorID": message.author.id,
+            "channel": message.channel.name, "channelID": message.channel.id, "content": message.content,
+            "jumpURL": message.jump_url, "attachments": [item.url for item in message.attachments]})
+        settings = self.settings()
+        lowered = message.content.lower().strip()
+
+        # Prevent image dumps from accounts that have not reached Member+.
+        # This focused safety rule stays active when general AutoMod is off.
+        image_attachments = [attachment for attachment in message.attachments
+                             if is_image_attachment(attachment.content_type, attachment.filename)]
+        if len(image_attachments) >= 4 and not gatekeeper.has(message.guild, message.author, 1):
+            image_rule = dict(settings["automod"])
+            image_rule.update({"deleteMessage": True, "timeoutHours": 168})
+            await self._moderate(message, image_rule,
+                                 f"{len(image_attachments)} images in one message from a user below Member+")
+            return
+
+        if message.author.id in self.afk:
+            self.afk.pop(message.author.id, None)
+            try:
+                await message.channel.send(f"Welcome back, {message.author.mention}. I cleared your AFK status.", delete_after=7)
+            except discord.HTTPException:
+                pass
+        for member in message.mentions:
+            if member.id in self.afk:
+                await message.channel.send(f"{member.display_name} is AFK: {self.afk[member.id]}", reference=message, mention_author=False)
+
+        for item in settings.get("customCommands", []):
+            if item.get("enabled", True) and lowered == str(item.get("trigger", "")).lower().strip():
+                await message.channel.send(str(item.get("response", ""))[:2000], reference=message, mention_author=False)
+                break
+        for item in settings.get("autoResponses", []):
+            trigger = str(item.get("trigger", "")).lower().strip()
+            match_mode = str(item.get("matchMode", "contains"))
+            matched = lowered == trigger if match_mode == "exact" else bool(re.search(rf"(?<!\w){re.escape(trigger)}(?!\w)", lowered)) if match_mode == "word" else trigger in lowered
+            allowed_channels = {int(value) for value in item.get("channelIDs", []) if str(value).isdigit()}
+            message_channels = {message.channel.id, int(getattr(message.channel, "parent_id", 0) or 0)}
+            if (item.get("enabled", True) and trigger and matched
+                    and (not allowed_channels or allowed_channels & message_channels)):
+                emoji_text = str(item.get("emojiText", ""))[:100]
+                content = " ".join(value for value in (emoji_text, str(item.get("response", ""))[:1900]) if value).strip()
+                sticker = message.guild.get_sticker(int(item.get("stickerID", 0) or 0))
+                for reaction in item.get("reactionEmojis", [])[:10]:
+                    try:
+                        await message.add_reaction(str(reaction))
+                    except discord.HTTPException:
+                        logger.warning("Could not add configured automatic reaction %s", reaction)
+                if content or sticker:
+                    send_options = {"reference": message, "mention_author": False}
+                    if sticker:
+                        send_options["stickers"] = [sticker]
+                    await message.channel.send(content or None, **send_options)
+                break
+
+        auto = settings["automod"]
+        monitored = set(auto.get("monitoredChannelIDs", []))
+        channel_ids = {message.channel.id, getattr(message.channel, "parent_id", 0)}
+        if (not auto.get("enabled") or self._staff(message.author, auto)
+                or channel_ids & set(auto.get("ignoredChannelIDs", []))
+                or (not auto.get("monitorAllChannels", True) and not channel_ids & monitored)):
+            return
+        now = time.monotonic()
+        key = (message.guild.id, message.author.id)
+        self.activity[key].append(now)
+        if image_attachments:
+            self.images[key].extend([now] * len(image_attachments))
+        findings = []
+        window = int(auto.get("imageWindowSeconds", 20))
+        image_count = recent_count(self.images[key], now, window)
+        if auto.get("imageSpam") and image_count >= int(auto.get("imageThreshold", 4)):
+            findings.append(f"{image_count} image attachments in {window} seconds")
+        msg_window = int(auto.get("messageWindowSeconds", 8))
+        message_count = recent_count(self.activity[key], now, msg_window)
+        if auto.get("fastSpam") and message_count >= int(auto.get("messageThreshold", 7)):
+            findings.append(f"{message_count} messages in {msg_window} seconds")
+        if auto.get("capsSpam") and len(message.content) >= 20 and caps_percent(message.content) >= int(auto.get("capsPercent", 80)):
+            findings.append("mostly capital letters")
+        if auto.get("mentionSpam") and len(message.mentions) + len(message.role_mentions) >= int(auto.get("mentionThreshold", 6)):
+            findings.append("too many mentions")
+        if auto.get("inviteLinks") and has_invite(message.content):
+            findings.append("Discord invite link")
+        if findings:
+            await self._moderate(message, auto, findings[0])
+            self.activity[key].clear(); self.images[key].clear()
+
+    async def _moderate(self, message: discord.Message, settings: dict, trigger: str):
+        if settings.get("deleteMessage"):
+            try:
+                await message.delete()
+            except discord.HTTPException:
+                pass
+        hours = max(0, min(int(settings.get("timeoutHours", 0)), 336))
+        action = "Message removed"
+        if hours and isinstance(message.author, discord.Member) and message.author < message.guild.me.top_role:
+            try:
+                await message.author.timeout(datetime.now(timezone.utc) + timedelta(hours=hours), reason=f"GIR AutoMod: {trigger}")
+                action = f"Timed out for {hours} hours"
+            except discord.HTTPException:
+                action = "Message removed; timeout could not be applied"
+        report_id = int(settings.get("reportChannelID") or 0)
+        channel = message.guild.get_channel(report_id) if report_id else None
+        channel = channel or discord.utils.get(message.guild.text_channels, name="reports")
+        channel = channel or message.guild.get_channel(int(getattr(cfg.channels, "reports", 0) or 0))
+        if not channel:
+            return
+        embed = discord.Embed(title="🚨 Automatic moderation alert", color=discord.Color.red(), timestamp=datetime.now(timezone.utc))
+        embed.add_field(name="Member", value=f"{message.author.mention}\n`{message.author.id}`", inline=False)
+        embed.add_field(name="Channel", value=message.channel.mention, inline=True)
+        embed.add_field(name="Trigger", value=trigger, inline=True)
+        embed.add_field(name="Action", value=action, inline=False)
+        if message.attachments:
+            embed.set_image(url=message.attachments[0].url)
+        view = discord.ui.View(timeout=None)
+        view.add_item(discord.ui.Button(label="Ban", style=discord.ButtonStyle.danger, custom_id=f"gir:report:ban:{message.author.id}"))
+        view.add_item(discord.ui.Button(label="Dismiss", style=discord.ButtonStyle.secondary, custom_id=f"gir:report:dismiss:{message.author.id}"))
+        await channel.send(embed=embed, view=view)
+
+    @commands.Cog.listener()
+    async def on_interaction(self, interaction: discord.Interaction):
+        custom_id = (interaction.data or {}).get("custom_id", "") if interaction.type == discord.InteractionType.component else ""
+        if not custom_id.startswith("gir:report:"):
+            return
+        _, _, action, user_id = custom_id.split(":", 3)
+        if action == "ban":
+            if not interaction.user.guild_permissions.ban_members:
+                await interaction.response.send_message("You need permission to ban members to use this.", ephemeral=True); return
+            try:
+                await interaction.guild.ban(discord.Object(id=int(user_id)), reason=f"Reviewed AutoMod report by {interaction.user}")
+                await interaction.response.edit_message(content=f"Banned by {interaction.user.mention}", view=None)
+            except discord.Forbidden:
+                await interaction.response.send_message("Discord would not allow that ban. Check GIR's Ban Members permission and role position.", ephemeral=True)
+        else:
+            if not interaction.user.guild_permissions.manage_messages:
+                await interaction.response.send_message("You need permission to manage messages to dismiss reports.", ephemeral=True); return
+            await interaction.response.edit_message(content=f"Dismissed by {interaction.user.mention}", view=None)
+
+    @commands.Cog.listener()
+    async def on_raw_reaction_add(self, payload: discord.RawReactionActionEvent):
+        if payload.guild_id != cfg.guild_id or payload.member is None or payload.member.bot:
+            return
+        channel = self.bot.get_channel(payload.channel_id)
+        self._queue_relay("reaction", payload.channel_id, {"author": str(payload.member), "authorID": payload.user_id,
+            "channel": getattr(channel, "name", "unknown"), "channelID": payload.channel_id,
+            "content": str(payload.emoji), "detail": "Reaction added",
+            "jumpURL": f"https://discord.com/channels/{payload.guild_id}/{payload.channel_id}/{payload.message_id}"})
+        settings = self.settings()
+        for item in settings.get("reactionRoles", []):
+            if item.get("enabled", True) and int(item.get("messageID", 0)) == payload.message_id and str(item.get("emoji")) == str(payload.emoji):
+                role = payload.member.guild.get_role(int(item.get("roleID", 0)))
+                if role:
+                    await payload.member.add_roles(role, reason="GIR reaction role")
+        star = settings["starboard"]
+        if not star.get("enabled") or str(payload.emoji) != str(star.get("emoji", "⭐")):
+            return
+        channel = self.bot.get_channel(payload.channel_id)
+        destination = self.bot.get_channel(int(star.get("channelID") or 0))
+        if not channel or not destination:
+            return
+        try:
+            message = await channel.fetch_message(payload.message_id)
+        except discord.HTTPException:
+            return
+        reaction = next((r for r in message.reactions if str(r.emoji) == str(payload.emoji)), None)
+        if not reaction or reaction.count < int(star.get("threshold", 3)):
+            return
+        embed = discord.Embed(description=message.content or "Shared attachment", color=discord.Color.gold(), timestamp=message.created_at)
+        embed.set_author(name=str(message.author), icon_url=message.author.display_avatar.url)
+        embed.add_field(name="Original", value=f"[Open message]({message.jump_url})")
+        if message.attachments:
+            embed.set_image(url=message.attachments[0].url)
+        existing = self.star_posts.get(message.id)
+        if existing:
+            try:
+                post = await destination.fetch_message(existing); await post.edit(content=f"⭐ **{reaction.count}**", embed=embed); return
+            except discord.HTTPException:
+                pass
+        post = await destination.send(content=f"⭐ **{reaction.count}**", embed=embed)
+        self.star_posts[message.id] = post.id
+
+    @commands.Cog.listener()
+    async def on_raw_reaction_remove(self, payload: discord.RawReactionActionEvent):
+        if payload.guild_id != cfg.guild_id:
+            return
+        guild = self.bot.get_guild(payload.guild_id); member = guild.get_member(payload.user_id) if guild else None
+        channel = self.bot.get_channel(payload.channel_id)
+        if member and not member.bot:
+            self._queue_relay("reaction", payload.channel_id, {"author": str(member), "authorID": payload.user_id,
+                "channel": getattr(channel, "name", "unknown"), "channelID": payload.channel_id,
+                "content": str(payload.emoji), "detail": "Reaction removed",
+                "jumpURL": f"https://discord.com/channels/{payload.guild_id}/{payload.channel_id}/{payload.message_id}"})
+        for item in self.settings().get("reactionRoles", []):
+            if item.get("enabled", True) and int(item.get("messageID", 0)) == payload.message_id and str(item.get("emoji")) == str(payload.emoji):
+                guild = self.bot.get_guild(payload.guild_id); member = guild.get_member(payload.user_id) if guild else None
+                role = guild.get_role(int(item.get("roleID", 0))) if guild else None
+                if member and role:
+                    await member.remove_roles(role, reason="GIR reaction role removed")
+
+    @commands.Cog.listener()
+    async def on_message_edit(self, before: discord.Message, after: discord.Message):
+        if not before.guild or before.guild.id != cfg.guild_id or before.author.bot or before.content == after.content:
+            return
+        self._queue_relay("edit", before.channel.id, {"author": str(before.author), "authorID": before.author.id,
+            "channel": before.channel.name, "channelID": before.channel.id,
+            "content": f"Before:\n{before.content[:1600]}\n\nAfter:\n{after.content[:1600]}", "jumpURL": after.jump_url})
+
+    @commands.Cog.listener()
+    async def on_raw_message_delete(self, payload: discord.RawMessageDeleteEvent):
+        message = payload.cached_message
+        if payload.guild_id != cfg.guild_id or not message or message.author.bot:
+            return
+        self._queue_relay("delete", payload.channel_id, {"author": str(message.author), "authorID": message.author.id,
+            "channel": message.channel.name, "channelID": payload.channel_id, "content": message.content,
+            "attachments": [item.url for item in message.attachments]})
+
+    @app_commands.guilds(cfg.guild_id)
+    @app_commands.command(name="suggest", description="Send an idea to the server suggestion board")
+    async def suggest(self, interaction: discord.Interaction, idea: str):
+        settings = self.settings()["suggestions"]
+        channel = interaction.guild.get_channel(int(settings.get("channelID") or 0)) if settings.get("enabled") else None
+        if not channel:
+            await interaction.response.send_message("Suggestions are not set up yet.", ephemeral=True); return
+        embed = discord.Embed(title="New suggestion", description=idea[:4000], color=discord.Color.teal())
+        embed.set_author(name=interaction.user.display_name, icon_url=interaction.user.display_avatar.url)
+        post = await channel.send(embed=embed); await post.add_reaction("👍"); await post.add_reaction("👎")
+        await interaction.response.send_message("Your suggestion was posted.", ephemeral=True)
+
+    @app_commands.default_permissions(manage_messages=True)
+    @app_commands.guilds(cfg.guild_id)
+    @app_commands.command(name="announce", description="Create and post a custom embed in a channel")
+    async def announce(self, interaction: discord.Interaction, channel: discord.TextChannel, title: str, message: str,
+                       color: str = "5865F2", image_url: str | None = None,
+                       thumbnail_url: str | None = None, footer: str | None = None):
+        color_value = color.lstrip("#")
+        try:
+            if len(color_value) != 6:
+                raise ValueError
+            embed_color = discord.Color(int(color_value, 16))
+        except ValueError:
+            await interaction.response.send_message("Use a six-character color such as 5865F2.", ephemeral=True); return
+        for label, value in (("image", image_url), ("thumbnail", thumbnail_url)):
+            if value and not value.startswith("https://"):
+                await interaction.response.send_message(f"The {label} must use an HTTPS link.", ephemeral=True); return
+        embed = discord.Embed(title=title[:256], description=message[:4000], color=embed_color, timestamp=datetime.now(timezone.utc))
+        if image_url:
+            embed.set_image(url=image_url)
+        if thumbnail_url:
+            embed.set_thumbnail(url=thumbnail_url)
+        embed.set_footer(text=(footer or f"Posted by {interaction.user.display_name}")[:2048])
+        await channel.send(embed=embed, allowed_mentions=discord.AllowedMentions.none())
+        await interaction.response.send_message("Embed posted.", ephemeral=True)
+
+    @app_commands.default_permissions(manage_channels=True)
+    @app_commands.guilds(cfg.guild_id)
+    @app_commands.command(name="slowmode", description="Change how often members can send messages")
+    async def slowmode(self, interaction: discord.Interaction, seconds: app_commands.Range[int, 0, 21600]):
+        await interaction.channel.edit(slowmode_delay=seconds, reason=f"Changed by {interaction.user}")
+        await interaction.response.send_message("Slow mode turned off." if seconds == 0 else f"Members can now send one message every {seconds} seconds.", ephemeral=True)
+
+    @app_commands.guilds(cfg.guild_id)
+    @app_commands.command(name="report", description="Privately report a member to the moderation team")
+    async def report(self, interaction: discord.Interaction, member: discord.Member, reason: str):
+        channel = interaction.guild.get_channel(int(getattr(cfg.channels, "reports", 0)))
+        if not channel:
+            await interaction.response.send_message("The reports channel is not set up yet.", ephemeral=True); return
+        embed = discord.Embed(title="Member report", description=reason[:4000], color=discord.Color.orange(), timestamp=datetime.now(timezone.utc))
+        embed.add_field(name="Reported member", value=f"{member.mention}\n`{member.id}`")
+        embed.add_field(name="Reported by", value=f"{interaction.user.mention}\n`{interaction.user.id}`")
+        await channel.send(embed=embed); await interaction.response.send_message("Your report was sent privately to the moderators.", ephemeral=True)
+
+    @app_commands.guilds(cfg.guild_id)
+    @app_commands.command(name="afk", description="Let people know you are away")
+    async def afk_command(self, interaction: discord.Interaction, reason: str = "Away for a while"):
+        self.afk[interaction.user.id] = reason[:200]
+        await interaction.response.send_message("Your AFK status is set. It will clear when you send a message.", ephemeral=True)
+
+    @app_commands.guilds(cfg.guild_id)
+    @app_commands.command(name="coinflip", description="Flip a coin")
+    async def coinflip(self, interaction: discord.Interaction):
+        await interaction.response.send_message(random.choice(("Heads 🪙", "Tails 🪙")))
+
+    @app_commands.guilds(cfg.guild_id)
+    @app_commands.command(name="roll", description="Roll dice")
+    async def roll(self, interaction: discord.Interaction, sides: app_commands.Range[int, 2, 1000] = 6):
+        await interaction.response.send_message(f"🎲 You rolled **{random.randint(1, sides)}** out of {sides}.")
+
+    @app_commands.guilds(cfg.guild_id)
+    @app_commands.command(name="choose", description="Let GIR choose from a comma-separated list")
+    async def choose(self, interaction: discord.Interaction, choices: str):
+        items = [item.strip() for item in choices.split(",") if item.strip()]
+        if len(items) < 2:
+            await interaction.response.send_message("Give me at least two choices separated by commas.", ephemeral=True); return
+        await interaction.response.send_message(f"I choose **{random.choice(items)}**.")
+
+    @app_commands.default_permissions(manage_nicknames=True)
+    @app_commands.guilds(cfg.guild_id)
+    @app_commands.command(name="nickname", description="Change or clear a member's nickname")
+    async def nickname(self, interaction: discord.Interaction, member: discord.Member, nickname: str | None = None):
+        await member.edit(nick=nickname, reason=f"Changed by {interaction.user}")
+        await interaction.response.send_message("Nickname updated.", ephemeral=True)
+
+    games = app_commands.Group(name="games", description="Free game alerts and current giveaways", guild_ids=[cfg.guild_id])
+
+    @games.command(name="free", description="List free games and giveaways available now")
+    async def games_free(self, interaction: discord.Interaction):
+        await interaction.response.defer(ephemeral=True)
+        settings = self.settings()["freeGames"]
+        try:
+            games = self.filtered_games(await self.fetch_free_games(settings), settings)[:10]
+        except Exception:
+            await interaction.followup.send("I could not reach the free-game list right now.", ephemeral=True); return
+        if not games:
+            await interaction.followup.send("No matching giveaways are listed right now.", ephemeral=True); return
+        lines = [f"• [{game.get('title', 'Free game')}]({game.get('open_giveaway_url') or game.get('gamerpower_url')}) — {game.get('platforms', 'Unknown platform')}" for game in games]
+        embed = discord.Embed(title="Free games available now", description="\n".join(lines)[:4000], color=discord.Color.green())
+        embed.add_field(name="Sources", value=", ".join(sorted({str(game.get("source", "Unknown")) for game in games})))
+        await interaction.followup.send(embed=embed, ephemeral=True)
+
+    @games.command(name="status", description="Show how free-game alerts are configured")
+    async def games_status(self, interaction: discord.Interaction):
+        settings = self.settings()["freeGames"]
+        channel = interaction.guild.get_channel(int(settings.get("channelID") or 0))
+        embed = discord.Embed(title="Free-game alerts", color=discord.Color.green())
+        embed.add_field(name="Automatic alerts", value="On" if settings.get("enabled") else "Off")
+        embed.add_field(name="Channel", value=channel.mention if channel else "Not selected")
+        embed.add_field(name="Platforms", value=", ".join(settings.get("platforms", [])) or "All", inline=False)
+        embed.add_field(name="Offer types", value=", ".join(settings.get("types", [])) or "All")
+        embed.add_field(name="Minimum normal price", value=f"${float(settings.get('minimumWorth', 0) or 0):.2f}")
+        embed.add_field(name="Check schedule", value=f"Every {int(settings.get('checkMinutes', 15))} minutes")
+        health = "\n".join(f"**{name.title()}**: {state}" for name, state in sorted(self.game_provider_health.items()))
+        if health:
+            embed.add_field(name="Source health", value=health[:1024], inline=False)
+        runtime = {}
+        try:
+            runtime = json.loads(GAME_STATUS_FILE.read_text())
+        except (OSError, ValueError, TypeError):
+            pass
+        if runtime.get("lastCheck"):
+            checked = datetime.fromtimestamp(runtime["lastCheck"], timezone.utc)
+            embed.add_field(name="Last check", value=f"{discord.utils.format_dt(checked, 'R')} · {runtime.get('offersFound', 0)} matches · {runtime.get('posted', 0)} posted", inline=False)
+        await interaction.response.send_message(embed=embed, ephemeral=True)
+
+    @games.command(name="check", description="Check all enabled free-game sources now")
+    @app_commands.default_permissions(manage_guild=True)
+    async def games_check(self, interaction: discord.Interaction):
+        await interaction.response.defer(ephemeral=True)
+        result = await self.run_free_game_check(manual=True)
+        await interaction.followup.send(f"Check **{result['state']}** · {result.get('offersFound', 0)} matches · {result.get('posted', 0)} new posts.", ephemeral=True)
+
+    @games.command(name="preview", description="Preview the next matching free-game embed")
+    async def games_preview(self, interaction: discord.Interaction):
+        await interaction.response.defer(ephemeral=True)
+        settings = self.settings()["freeGames"]
+        games = self.filtered_games(await self.fetch_free_games(settings), settings)
+        if not games:
+            await interaction.followup.send("No matching offers are available to preview.", ephemeral=True); return
+        await interaction.followup.send(embed=self.game_embed(games[0]), view=self.game_view(games[0]), ephemeral=True)
+
+    movie = app_commands.Group(name="movie", description="Plan a server movie night", guild_ids=[cfg.guild_id])
+
+    @movie.command(name="suggest", description="Suggest a movie and let members vote")
+    async def movie_suggest(self, interaction: discord.Interaction, title: str, notes: str = ""):
+        settings = self.settings()["movieNight"]
+        channel = interaction.guild.get_channel(int(settings.get("channelID") or 0)) if settings.get("enabled") else None
+        if not channel:
+            await interaction.response.send_message("Movie night is not set up yet.", ephemeral=True); return
+        embed = discord.Embed(title=f"🎬 {title[:240]}", description=notes[:3500] or "Would you watch this?", color=discord.Color.purple())
+        embed.set_footer(text=f"Suggested by {interaction.user.display_name}")
+        post = await channel.send(embed=embed); await post.add_reaction("👍"); await post.add_reaction("👎")
+        await interaction.response.send_message("Your movie was added for voting.", ephemeral=True)
+
+    @movie.command(name="poll", description="Create a movie-night vote from comma-separated titles")
+    @app_commands.default_permissions(manage_events=True)
+    async def movie_poll(self, interaction: discord.Interaction, titles: str, when: str = "Date to be decided"):
+        options = [value.strip() for value in titles.split(",") if value.strip()][:10]
+        if len(options) < 2:
+            await interaction.response.send_message("Add at least two movie titles separated by commas.", ephemeral=True); return
+        settings = self.settings()["movieNight"]; channel = interaction.guild.get_channel(int(settings.get("channelID") or 0)) or interaction.channel
+        numbers = ["1️⃣", "2️⃣", "3️⃣", "4️⃣", "5️⃣", "6️⃣", "7️⃣", "8️⃣", "9️⃣", "🔟"]
+        embed = discord.Embed(title="🎬 Movie night vote", description="\n".join(f"{numbers[i]} {title}" for i, title in enumerate(options)), color=discord.Color.purple())
+        embed.add_field(name="When", value=when[:1024]); role = interaction.guild.get_role(int(settings.get("pingRoleID") or 0))
+        await interaction.response.defer(ephemeral=True); post = await channel.send(content=role.mention if role else None, embed=embed, allowed_mentions=discord.AllowedMentions(roles=True))
+        for emoji in numbers[:len(options)]: await post.add_reaction(emoji)
+        await interaction.followup.send("Movie-night vote posted.", ephemeral=True)
+
+    emoji = app_commands.Group(name="emoji", description="Manage server emojis", guild_ids=[cfg.guild_id], default_permissions=discord.Permissions(manage_emojis=True))
+
+    async def image_from_url(self, url: str) -> bytes:
+        if not url.startswith("https://"):
+            raise ValueError("Use an HTTPS image URL.")
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url, timeout=15) as response:
+                response.raise_for_status(); data = await response.read()
+        if len(data) > 256 * 1024: raise ValueError("Discord emoji images must be smaller than 256 KB.")
+        return data
+
+    @emoji.command(name="add", description="Add an emoji from an image URL")
+    async def emoji_add(self, interaction: discord.Interaction, name: str, image_url: str):
+        await interaction.response.defer(ephemeral=True)
+        try: emoji = await interaction.guild.create_custom_emoji(name=name[:32], image=await self.image_from_url(image_url), reason=f"Added by {interaction.user}")
+        except Exception as error: await interaction.followup.send(f"I could not add that emoji: {error}", ephemeral=True); return
+        await interaction.followup.send(f"Added {emoji}.", ephemeral=True)
+
+    @emoji.command(name="copy", description="Copy a custom emoji into this server")
+    async def emoji_copy(self, interaction: discord.Interaction, emoji: str, new_name: str = ""):
+        match = re.fullmatch(r"<a?:([A-Za-z0-9_]+):(\d+)>", emoji)
+        if not match: await interaction.response.send_message("Paste a custom Discord emoji, such as <:name:123>.", ephemeral=True); return
+        extension = "gif" if emoji.startswith("<a:") else "png"; url = f"https://cdn.discordapp.com/emojis/{match.group(2)}.{extension}"
+        await interaction.response.defer(ephemeral=True)
+        try: created = await interaction.guild.create_custom_emoji(name=(new_name or match.group(1))[:32], image=await self.image_from_url(url), reason=f"Copied by {interaction.user}")
+        except Exception as error: await interaction.followup.send(f"I could not copy that emoji: {error}", ephemeral=True); return
+        await interaction.followup.send(f"Added {created}.", ephemeral=True)
+
+    @emoji.command(name="delete", description="Delete a server emoji by name")
+    async def emoji_delete(self, interaction: discord.Interaction, name: str):
+        emoji = discord.utils.get(interaction.guild.emojis, name=name)
+        if not emoji: await interaction.response.send_message("I could not find that emoji.", ephemeral=True); return
+        await emoji.delete(reason=f"Deleted by {interaction.user}"); await interaction.response.send_message(f"Deleted `{name}`.", ephemeral=True)
+
+    @emoji.command(name="list", description="List this server's custom emojis")
+    async def emoji_list(self, interaction: discord.Interaction):
+        text = " ".join(str(emoji) for emoji in interaction.guild.emojis) or "This server has no custom emojis."
+        await interaction.response.send_message(text[:2000], ephemeral=True)
+
+    @emoji.command(name="stats", description="Show emoji capacity and usage")
+    async def emoji_stats(self, interaction: discord.Interaction):
+        static = sum(not item.animated for item in interaction.guild.emojis); animated = sum(item.animated for item in interaction.guild.emojis)
+        await interaction.response.send_message(f"Static emojis: **{static}**\nAnimated emojis: **{animated}**\nServer emoji limit: **{interaction.guild.emoji_limit}** per type", ephemeral=True)
+
+    @emoji.command(name="export", description="Export server emojis as a ZIP file")
+    async def emoji_export(self, interaction: discord.Interaction):
+        await interaction.response.defer(ephemeral=True); archive = BytesIO()
+        async with aiohttp.ClientSession() as session:
+            with zipfile.ZipFile(archive, "w", zipfile.ZIP_DEFLATED) as bundle:
+                for item in interaction.guild.emojis:
+                    try:
+                        async with session.get(item.url, timeout=15) as response: data = await response.read()
+                        bundle.writestr(f"{item.name}.{('gif' if item.animated else 'png')}", data)
+                    except Exception: pass
+        archive.seek(0); await interaction.followup.send(file=discord.File(archive, filename=f"{interaction.guild.name}-emojis.zip"), ephemeral=True)
+
+    @emoji.command(name="import", description="Import PNG, JPEG, GIF, or WebP images from a ZIP")
+    async def emoji_import(self, interaction: discord.Interaction, file: discord.Attachment):
+        if file.size > 8 * 1024 * 1024: await interaction.response.send_message("Choose a ZIP smaller than 8 MB.", ephemeral=True); return
+        await interaction.response.defer(ephemeral=True); added = 0
+        try:
+            with zipfile.ZipFile(BytesIO(await file.read())) as bundle:
+                safe = [info for info in bundle.infolist() if not info.is_dir() and info.file_size <= 256*1024 and info.filename.lower().endswith((".png", ".jpg", ".jpeg", ".gif", ".webp"))][:50]
+                for info in safe:
+                    name = re.sub(r"[^A-Za-z0-9_]", "_", Path(info.filename).stem)[:32]
+                    if len(name) < 2: continue
+                    try: await interaction.guild.create_custom_emoji(name=name, image=bundle.read(info), reason=f"Imported by {interaction.user}"); added += 1
+                    except discord.HTTPException: pass
+        except (zipfile.BadZipFile, OSError): await interaction.followup.send("That file is not a readable ZIP.", ephemeral=True); return
+        await interaction.followup.send(f"Imported **{added}** emojis.", ephemeral=True)
+
+    @emoji.command(name="role-icon", description="Set a role icon from an image URL")
+    async def emoji_role_icon(self, interaction: discord.Interaction, role: discord.Role, image_url: str):
+        await interaction.response.defer(ephemeral=True)
+        try: await role.edit(display_icon=await self.image_from_url(image_url), reason=f"Changed by {interaction.user}")
+        except Exception as error: await interaction.followup.send(f"I could not set that role icon: {error}", ephemeral=True); return
+        await interaction.followup.send("Role icon updated.", ephemeral=True)
+
+    @emoji.command(name="pfp", description="Make an emoji from a Discord user's profile picture")
+    async def emoji_pfp(self, interaction: discord.Interaction, name: str, discord_id: str):
+        if not discord_id.isdigit(): await interaction.response.send_message("Enter a numeric Discord user ID.", ephemeral=True); return
+        await interaction.response.defer(ephemeral=True)
+        try:
+            user = await self.bot.fetch_user(int(discord_id)); data = await user.display_avatar.with_size(128).read()
+            emoji = await interaction.guild.create_custom_emoji(name=name[:32], image=data, reason=f"Added by {interaction.user}")
+        except Exception as error: await interaction.followup.send(f"I could not create that emoji: {error}", ephemeral=True); return
+        await interaction.followup.send(f"Added {emoji} from {user}.", ephemeral=True)
+
+    sticker = app_commands.Group(name="sticker", description="Manage server stickers", guild_ids=[cfg.guild_id], default_permissions=discord.Permissions(manage_emojis=True))
+
+    @sticker.command(name="list", description="List this server's stickers")
+    async def sticker_list(self, interaction: discord.Interaction):
+        stickers = await interaction.guild.fetch_stickers(); text = "\n".join(f"• {item.name} — {item.url}" for item in stickers) or "This server has no stickers."
+        await interaction.response.send_message(text[:2000], ephemeral=True)
+
+    @sticker.command(name="add", description="Add a sticker from an image URL")
+    async def sticker_add(self, interaction: discord.Interaction, name: str, image_url: str, emoji: str, description: str = "Server sticker"):
+        await interaction.response.defer(ephemeral=True)
+        try:
+            data = await self.image_from_url(image_url); extension = Path(image_url.split("?", 1)[0]).suffix.lower() or ".png"
+            sticker = await interaction.guild.create_sticker(name=name[:30], description=description[:100], emoji=emoji, file=discord.File(BytesIO(data), filename="sticker" + extension), reason=f"Added by {interaction.user}")
+        except Exception as error: await interaction.followup.send(f"I could not add that sticker: {error}", ephemeral=True); return
+        await interaction.followup.send(f"Added sticker `{sticker.name}`.", ephemeral=True)
+
+    @sticker.command(name="delete", description="Delete a server sticker by name")
+    async def sticker_delete(self, interaction: discord.Interaction, name: str):
+        sticker = discord.utils.get(await interaction.guild.fetch_stickers(), name=name)
+        if not sticker: await interaction.response.send_message("I could not find that sticker.", ephemeral=True); return
+        await sticker.delete(reason=f"Deleted by {interaction.user}"); await interaction.response.send_message(f"Deleted `{name}`.", ephemeral=True)
+
+    @sticker.command(name="export", description="Export server stickers as a ZIP file")
+    async def sticker_export(self, interaction: discord.Interaction):
+        await interaction.response.defer(ephemeral=True); archive = BytesIO(); stickers = await interaction.guild.fetch_stickers()
+        async with aiohttp.ClientSession() as session:
+            with zipfile.ZipFile(archive, "w", zipfile.ZIP_DEFLATED) as bundle:
+                for item in stickers:
+                    try:
+                        async with session.get(item.url, timeout=15) as response: data = await response.read()
+                        extension = ".png" if item.format in {discord.StickerFormatType.png, discord.StickerFormatType.apng} else ".json"
+                        bundle.writestr(item.name + extension, data)
+                    except Exception: pass
+        archive.seek(0); await interaction.followup.send(file=discord.File(archive, filename=f"{interaction.guild.name}-stickers.zip"), ephemeral=True)
+
+    @sticker.command(name="import", description="Import PNG or APNG stickers from a ZIP")
+    async def sticker_import(self, interaction: discord.Interaction, file: discord.Attachment):
+        if file.size > 8 * 1024 * 1024: await interaction.response.send_message("Choose a ZIP smaller than 8 MB.", ephemeral=True); return
+        await interaction.response.defer(ephemeral=True); added = 0
+        try:
+            with zipfile.ZipFile(BytesIO(await file.read())) as bundle:
+                safe = [info for info in bundle.infolist() if not info.is_dir() and info.file_size <= 512*1024 and info.filename.lower().endswith((".png", ".apng"))][:15]
+                for info in safe:
+                    name = re.sub(r"[^A-Za-z0-9_ ]", "", Path(info.filename).stem)[:30]
+                    if len(name) < 2: continue
+                    try:
+                        upload = discord.File(BytesIO(bundle.read(info)), filename=Path(info.filename).name)
+                        await interaction.guild.create_sticker(name=name, description="Imported by GIR", emoji="⭐", file=upload, reason=f"Imported by {interaction.user}"); added += 1
+                    except discord.HTTPException: pass
+        except (zipfile.BadZipFile, OSError): await interaction.followup.send("That file is not a readable ZIP.", ephemeral=True); return
+        await interaction.followup.send(f"Imported **{added}** stickers.", ephemeral=True)
+
+
+async def setup(bot):
+    await bot.add_cog(CommunitySuite(bot))

--- a/cogs/monitors/utils/jailbreak_monitors.py
+++ b/cogs/monitors/utils/jailbreak_monitors.py
@@ -106,7 +106,7 @@ class Sileo(commands.Cog):
             return
 
         urlscheme = re.search(
-            "(sileo|zbra):\/\/package\/([a-zA-Z0-9]+(\.[a-zA-Z0-9]+)+(\.[a-zA-Z0-9]+)+)", message.content)
+                r"(sileo|zbra)://package/([a-zA-Z0-9]+(\.[a-zA-Z0-9]+)+(\.[a-zA-Z0-9]+)+)", message.content)
 
         if urlscheme is None:
             return

--- a/cogs/server_suite.py
+++ b/cogs/server_suite.py
@@ -1,0 +1,319 @@
+"""Server-aware engagement, moderation, Apple event, and firmware tools."""
+from __future__ import annotations
+
+import asyncio
+import difflib
+import hashlib
+import os
+import random
+import re
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+
+import aiohttp
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+from utils import cfg, logger
+
+
+IPSW_API = "https://api.ipsw.me/v4"
+APPLE_EVENTS = "https://www.apple.com/apple-events/"
+APPLE_NEWSROOM = "https://www.apple.com/newsroom/"
+TSSCHECKER = os.environ.get("TSSCHECKER_PATH", shutil.which("tsschecker") or "")
+
+QUESTIONS = (
+    "What small thing made your day better?", "What game deserves a remake?", "What is your perfect weekend?",
+    "Which skill would you learn instantly?", "What song never gets old?", "What is your favorite comfort food?",
+)
+WOULD_YOU_RATHER = (
+    "Would you rather explore space or the deepest ocean?", "Would you rather have unlimited travel or unlimited food?",
+    "Would you rather always be ten minutes early or never wait in line?", "Would you rather relive one day or skip one bad day?",
+)
+COMPLIMENTS = ("brings great energy", "makes this server more fun", "has excellent taste", "is someone people can count on")
+
+
+class ServerSuite(commands.Cog):
+    engage = app_commands.Group(name="engage", description="Games and friendly community activities", guild_ids=[cfg.guild_id])
+    modtools = app_commands.Group(name="modtools", description="Extra tools for moderators", guild_ids=[cfg.guild_id],
+                                  default_permissions=discord.Permissions(manage_messages=True))
+    apple = app_commands.Group(name="apple", description="Official Apple event and developer links", guild_ids=[cfg.guild_id])
+    tss = app_commands.Group(name="tss", description="Check Apple firmware signing and device support", guild_ids=[cfg.guild_id])
+
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+        self._devices = []
+        self._device_cache_time = 0.0
+
+    @engage.command(name="eightball", description="Ask GIR a yes-or-no question")
+    async def eightball(self, interaction: discord.Interaction, question: str):
+        answer = random.choice(("Yes.", "Probably.", "Signs point to yes.", "Ask again later.", "Probably not.", "No."))
+        await interaction.response.send_message(f"🎱 **{question[:300]}**\n{answer}")
+
+    @engage.command(name="question", description="Post a conversation starter")
+    async def question(self, interaction: discord.Interaction):
+        await interaction.response.send_message("💬 " + random.choice(QUESTIONS))
+
+    @engage.command(name="would-you-rather", description="Post a would-you-rather question")
+    async def would_you_rather(self, interaction: discord.Interaction):
+        await interaction.response.send_message("🤔 " + random.choice(WOULD_YOU_RATHER))
+
+    @engage.command(name="compliment", description="Send a friendly compliment")
+    async def compliment(self, interaction: discord.Interaction, member: discord.Member):
+        await interaction.response.send_message(f"✨ {member.mention} {random.choice(COMPLIMENTS)}.")
+
+    @engage.command(name="highfive", description="Give someone a high five")
+    async def highfive(self, interaction: discord.Interaction, member: discord.Member):
+        await interaction.response.send_message(f"🙌 {interaction.user.mention} high-fived {member.mention}!")
+
+    @engage.command(name="hug", description="Send someone a friendly hug")
+    async def hug(self, interaction: discord.Interaction, member: discord.Member):
+        await interaction.response.send_message(f"🫂 {interaction.user.mention} sent {member.mention} a hug.")
+
+    @engage.command(name="match", description="Calculate a repeatable friendship score")
+    async def match(self, interaction: discord.Interaction, first: discord.Member, second: discord.Member):
+        pair = ":".join(map(str, sorted((first.id, second.id)))).encode()
+        score = int(hashlib.sha256(pair).hexdigest()[:8], 16) % 101
+        await interaction.response.send_message(f"💚 {first.mention} + {second.mention}: **{score}%** match")
+
+    @engage.command(name="decide", description="Choose fairly from a list separated by commas")
+    async def decide(self, interaction: discord.Interaction, choices: str):
+        items = [item.strip() for item in choices.split(",") if item.strip()]
+        if len(items) < 2:
+            await interaction.response.send_message("Give me at least two choices separated by commas.", ephemeral=True); return
+        await interaction.response.send_message(f"🎯 GIR chooses **{random.choice(items)}**")
+
+    @engage.command(name="random-member", description="Choose a random non-bot member")
+    async def random_member(self, interaction: discord.Interaction):
+        choices = [member for member in interaction.guild.members if not member.bot]
+        if not choices:
+            await interaction.response.send_message("I could not find an eligible member.", ephemeral=True); return
+        await interaction.response.send_message(f"🎉 {random.choice(choices).mention} was chosen!")
+
+    @modtools.command(name="role-add", description="Give a manageable role to a member")
+    async def role_add(self, interaction: discord.Interaction, member: discord.Member, role: discord.Role):
+        if role >= interaction.guild.me.top_role or role.is_default() or role.managed:
+            await interaction.response.send_message("GIR cannot manage that role. Move GIR above it or choose another role.", ephemeral=True); return
+        await member.add_roles(role, reason=f"Added by {interaction.user}")
+        await interaction.response.send_message(f"Added {role.mention} to {member.mention}.", ephemeral=True)
+
+    @modtools.command(name="role-remove", description="Remove a manageable role from a member")
+    async def role_remove(self, interaction: discord.Interaction, member: discord.Member, role: discord.Role):
+        if role >= interaction.guild.me.top_role or role.is_default() or role.managed:
+            await interaction.response.send_message("GIR cannot manage that role. Move GIR above it or choose another role.", ephemeral=True); return
+        await member.remove_roles(role, reason=f"Removed by {interaction.user}")
+        await interaction.response.send_message(f"Removed {role.mention} from {member.mention}.", ephemeral=True)
+
+    @modtools.command(name="permissions", description="Explain what GIR can do to a member")
+    async def permissions(self, interaction: discord.Interaction, member: discord.Member):
+        manageable = member != interaction.guild.owner and member.top_role < interaction.guild.me.top_role
+        await interaction.response.send_message(
+            f"**{member.display_name}**\nTop role: {member.top_role.mention}\n"
+            f"GIR can moderate this member: **{'Yes' if manageable else 'No'}**\n"
+            f"Administrator: **{'Yes' if member.guild_permissions.administrator else 'No'}**", ephemeral=True)
+
+    @modtools.command(name="clear-reactions", description="Remove every reaction from a message")
+    async def clear_reactions(self, interaction: discord.Interaction, message_id: str):
+        if not message_id.isdigit():
+            await interaction.response.send_message("Enter a numeric message ID.", ephemeral=True); return
+        try:
+            message = await interaction.channel.fetch_message(int(message_id)); await message.clear_reactions()
+        except discord.HTTPException:
+            await interaction.response.send_message("I could not find that message or clear its reactions.", ephemeral=True); return
+        await interaction.response.send_message("Reactions cleared.", ephemeral=True)
+
+    @modtools.command(name="role-members", description="List members who have a role")
+    async def role_members(self, interaction: discord.Interaction, role: discord.Role):
+        names = [member.mention for member in role.members]
+        text = " ".join(names[:80]) or "No cached members have this role."
+        if len(names) > 80:
+            text += f"\n…and {len(names) - 80} more."
+        await interaction.response.send_message(f"**{role.name} · {len(names)} members**\n{text}"[:2000], ephemeral=True)
+
+    @modtools.command(name="channel-info", description="Show a channel's IDs, topic, and rate limit")
+    async def channel_info(self, interaction: discord.Interaction, channel: discord.TextChannel):
+        await interaction.response.send_message(
+            f"**#{channel.name}**\nID: `{channel.id}`\nCategory: {channel.category.name if channel.category else 'None'}\n"
+            f"Slow mode: {channel.slowmode_delay} seconds\nTopic: {channel.topic or 'None'}", ephemeral=True)
+
+    @modtools.command(name="bots", description="List bot accounts currently in the server cache")
+    async def bots(self, interaction: discord.Interaction):
+        bots = [member for member in interaction.guild.members if member.bot]
+        text = "\n".join(f"• {member} · `{member.id}`" for member in bots[:50]) or "No bots found."
+        await interaction.response.send_message(f"**Bots · {len(bots)}**\n{text}"[:2000], ephemeral=True)
+
+    async def _get_json(self, url: str):
+        async with aiohttp.ClientSession(headers={"User-Agent": "GIR/1.0"}) as session:
+            async with session.get(url, timeout=aiohttp.ClientTimeout(total=10)) as response:
+                response.raise_for_status(); return await response.json()
+
+    async def _get_devices(self):
+        now = asyncio.get_running_loop().time()
+        if self._devices and now - self._device_cache_time < 3600:
+            return self._devices
+        self._devices = await self._get_json(IPSW_API + "/devices")
+        self._device_cache_time = now
+        return self._devices
+
+    @staticmethod
+    def _normalise_device_name(value: str):
+        value = value.casefold().replace("‑", "-")
+        value = re.sub(r"\b(1st|2nd|3rd|([4-9]|\d{2,})th)\s+(generation|gen)\b", r"\1", value)
+        value = re.sub(r"\b(first|second|third|fourth|fifth|sixth|seventh|eighth|ninth|tenth)\s+(generation|gen)\b", r"\1", value)
+        number_words = {"first": "1", "second": "2", "third": "3", "fourth": "4", "fifth": "5",
+                        "sixth": "6", "seventh": "7", "eighth": "8", "ninth": "9", "tenth": "10"}
+        for word, number in number_words.items():
+            value = re.sub(rf"\b{word}\b", number, value)
+        value = re.sub(r"(\d+)(st|nd|rd|th)\b", r"\1", value)
+        return re.sub(r"[^a-z0-9]+", " ", value).strip()
+
+    async def _find_device(self, device_text: str):
+        devices = await self._get_devices()
+        names = {self._normalise_device_name(str(item["name"])): item for item in devices}
+        identifiers = {str(item["identifier"]).casefold(): item for item in devices}
+        raw = device_text.strip().casefold()
+        needle = self._normalise_device_name(device_text)
+        device = names.get(needle) or identifiers.get(raw)
+        if not device:
+            prefix_matches = [item for name, item in names.items() if name.startswith(needle + " ")]
+            device = prefix_matches[0] if prefix_matches else None
+        if not device:
+            match = difflib.get_close_matches(needle, list(names) + list(identifiers), n=1, cutoff=.58)
+            device = (names.get(match[0]) or identifiers.get(match[0])) if match else None
+        if not device:
+            raise ValueError(f"I could not match “{device_text}” to an Apple device.")
+        return device
+
+    async def _check_signing(self, device_text: str, version: str):
+        version_match = re.search(r"\d+(?:\.\d+){1,2}", version)
+        if not version_match:
+            raise ValueError("Enter an iOS version such as 18.6 or 26.0.")
+        device = await self._find_device(device_text)
+        version = version_match.group(0)
+        data = await self._get_json(f"{IPSW_API}/device/{device['identifier']}?type=ipsw")
+        firmware = next((item for item in data.get("firmwares", []) if item.get("version") == version), None)
+        if not firmware:
+            return device, version, "incompatible", "That iOS version was not released for this device."
+        signed = bool(firmware.get("signed"))
+        return device, version, "signed" if signed else "unsigned", "Checked against the live Apple firmware signing catalog."
+
+    @tss.command(name="check", description="Check whether an iOS version is signed for a device")
+    @app_commands.describe(
+        device="Apple device name or identifier, such as iPhone X or iPhone10,3",
+        ios_version="iOS or iPadOS version, such as 16.7.12 or 26.0",
+    )
+    async def tss_check(self, interaction: discord.Interaction, device: str, ios_version: str):
+        await interaction.response.defer()
+        try:
+            device, version, status_code, note = await asyncio.wait_for(
+                self._check_signing(device, ios_version), timeout=25
+            )
+        except asyncio.TimeoutError:
+            await interaction.followup.send(
+                "The signing catalog did not answer within 25 seconds. Please try again.", ephemeral=True
+            ); return
+        except (ValueError, aiohttp.ClientError) as error:
+            await interaction.followup.send(str(error), ephemeral=True); return
+        status, color = {
+            "signed": ("Signed", discord.Color.green()), "unsigned": ("Not signed", discord.Color.red()),
+            "incompatible": ("Not compatible", discord.Color.orange()),
+            "uncertain": ("Needs another check", discord.Color.orange()),
+        }[status_code]
+        embed = discord.Embed(title=f"{device['name']} · iOS {version}", description=f"**{status}**\n{note}", color=color,
+                              timestamp=datetime.now(timezone.utc))
+        embed.add_field(name="Device identifier", value=device["identifier"])
+        await interaction.followup.send(embed=embed)
+
+    @tss_check.autocomplete("device")
+    async def tss_device_autocomplete(self, interaction: discord.Interaction, current: str):
+        try:
+            devices = await self._get_devices()
+        except aiohttp.ClientError:
+            return []
+        needle = self._normalise_device_name(current)
+        ranked = []
+        for item in devices:
+            name = str(item.get("name", ""))
+            identifier = str(item.get("identifier", ""))
+            haystack = self._normalise_device_name(f"{name} {identifier}")
+            if needle and needle not in haystack:
+                continue
+            family_rank = 0 if name.startswith(("iPhone", "iPad")) else 1
+            ranked.append((family_rank, name.casefold(), name, identifier))
+        ranked.sort()
+        return [app_commands.Choice(name=f"{name} · {identifier}"[:100], value=identifier[:100])
+                for _, _, name, identifier in ranked[:25]]
+
+    @tss_check.autocomplete("ios_version")
+    async def tss_version_autocomplete(self, interaction: discord.Interaction, current: str):
+        device_text = str(getattr(interaction.namespace, "device", "") or "")
+        if not device_text:
+            return []
+        try:
+            device = await self._find_device(device_text)
+            data = await self._get_json(f"{IPSW_API}/device/{device['identifier']}?type=ipsw")
+        except (ValueError, aiohttp.ClientError):
+            return []
+        versions = list(dict.fromkeys(str(item.get("version")) for item in data.get("firmwares", []) if item.get("version")))
+        matches = [version for version in versions if not current or version.startswith(current.strip())]
+        return [app_commands.Choice(name=version, value=version) for version in matches[:25]]
+
+    @tss.command(name="device", description="Find the identifier GIR uses for an Apple device")
+    async def tss_device(self, interaction: discord.Interaction, device: str):
+        await interaction.response.defer(ephemeral=True)
+        try:
+            match = await self._find_device(device)
+            await interaction.followup.send(f"**{match['name']}** uses identifier `{match['identifier']}`.", ephemeral=True)
+        except (ValueError, aiohttp.ClientError) as error:
+            await interaction.followup.send(str(error), ephemeral=True)
+
+    @tss.command(name="versions", description="List currently signed iOS versions for a device")
+    async def tss_versions(self, interaction: discord.Interaction, device: str):
+        await interaction.response.defer()
+        try:
+            match = await self._find_device(device)
+            data = await self._get_json(f"{IPSW_API}/device/{match['identifier']}?type=ipsw")
+            signed = [item.get("version") for item in data.get("firmwares", []) if item.get("signed")]
+            versions = list(dict.fromkeys(value for value in signed if value))
+            text = ", ".join(versions[:20]) or "No signed iOS versions were reported."
+            await interaction.followup.send(f"**TSS signing for {match['name']}**\n{text}")
+        except (ValueError, aiohttp.ClientError) as error:
+            await interaction.followup.send(str(error), ephemeral=True)
+
+    @tss.command(name="status", description="Check whether GIR's signing checker is ready")
+    async def tss_status(self, interaction: discord.Interaction):
+        installed = Path(TSSCHECKER).is_file()
+        await interaction.response.send_message(
+            "**Fast signing checks:** Ready\n"
+            "Interactive checks use the live firmware catalog and have a 25-second deadline. No IPSW is downloaded.\n"
+            f"**Local TSSChecker utility:** {'Installed (not used for interactive checks)' if installed else 'Not installed'}",
+            ephemeral=True,
+        )
+
+    @tss.command(name="help", description="Show examples of every TSS command")
+    async def tss_help(self, interaction: discord.Interaction):
+        await interaction.response.send_message(
+            "**TSS commands**\n"
+            "`/tss check device:iPhone 16 ios_version:18.0`\n"
+            "`/tss device device:iPhone 16`\n"
+            "`/tss versions device:iPhone 16`\n"
+            "`/tss status`",
+            ephemeral=True,
+        )
+
+    @apple.command(name="events", description="Open Apple's official event page")
+    async def apple_events(self, interaction: discord.Interaction):
+        await interaction.response.send_message(f"🍎 Apple event schedule and replays: {APPLE_EVENTS}")
+
+    @apple.command(name="latest", description="Open Apple's official Newsroom")
+    async def apple_latest(self, interaction: discord.Interaction):
+        await interaction.response.send_message(f"🍎 Apple Newsroom: {APPLE_NEWSROOM}")
+
+    @apple.command(name="developer", description="Open Apple's developer event schedule")
+    async def apple_developer(self, interaction: discord.Interaction):
+        await interaction.response.send_message("Apple developer sessions, labs, and events: https://developer.apple.com/events/")
+
+async def setup(bot):
+    await bot.add_cog(ServerSuite(bot))

--- a/community_rules.py
+++ b/community_rules.py
@@ -1,0 +1,26 @@
+"""Pure detection helpers for the community suite."""
+import re
+
+
+INVITE_PATTERN = re.compile(r"(?:discord\.gg|discord(?:app)?\.com/invite)/[A-Za-z0-9-]+", re.I)
+IMAGE_EXTENSIONS = {".avif", ".gif", ".heic", ".heif", ".jpeg", ".jpg", ".png", ".webp"}
+
+
+def caps_percent(text: str) -> int:
+    letters = [char for char in text if char.isalpha()]
+    return round(100 * sum(char.isupper() for char in letters) / len(letters)) if letters else 0
+
+
+def has_invite(text: str) -> bool:
+    return bool(INVITE_PATTERN.search(text))
+
+
+def recent_count(timestamps: list[float], now: float, window_seconds: int) -> int:
+    return sum(now - stamp <= window_seconds for stamp in timestamps)
+
+
+def is_image_attachment(content_type, filename: str) -> bool:
+    """Recognize Discord image uploads even when their MIME type is unavailable."""
+    if content_type and content_type.casefold().startswith("image/"):
+        return True
+    return any(filename.casefold().endswith(extension) for extension in IMAGE_EXTENSIONS)

--- a/extensions.py
+++ b/extensions.py
@@ -1,4 +1,11 @@
-initial_extensions = [
+import json
+import os
+from pathlib import Path
+
+
+default_extensions = [
+    "cogs.community_suite",
+    "cogs.server_suite",
     "cogs.commands.info.devices",
     "cogs.commands.info.stats",
     "cogs.commands.info.help",
@@ -29,3 +36,13 @@ initial_extensions = [
     "cogs.monitors.utils.jailbreak_monitors",
     "cogs.monitors.utils.xp",
 ]
+
+feature_path = os.environ.get("GIR_FEATURE_FILE")
+if feature_path:
+    try:
+        enabled_extensions = set(json.loads(Path(feature_path).read_text()).get("enabled", []))
+        initial_extensions = [name for name in default_extensions if name in enabled_extensions]
+    except (OSError, ValueError, TypeError):
+        initial_extensions = list(default_extensions)
+else:
+    initial_extensions = list(default_extensions)

--- a/main.py
+++ b/main.py
@@ -1,6 +1,9 @@
 import asyncio
 import os
 import traceback
+import json
+import uuid
+from pathlib import Path
 import discord
 from discord.ext import commands
 from discord import app_commands
@@ -19,6 +22,8 @@ import warnings
 warnings.simplefilter(action='ignore', category=FutureWarning)
 
 
+# Keep the events GIR uses while avoiding presence and typing firehoses on very
+# large servers. Member and message-content access are checked by the dashboard.
 intents = discord.Intents.all()
 mentions = discord.AllowedMentions(everyone=False, users=True, roles=False)
 
@@ -42,6 +47,13 @@ class Bot(commands.Bot):
 
         setup_context_commands(self)
 
+        # Keep slash commands current without requiring the owner to run !sync
+        # after an update. GIR's commands are guild-scoped, so this takes effect
+        # immediately in the configured server.
+        if os.environ.get("GIR_SYNC_COMMANDS", "True") == "True":
+            synced = await self.tree.sync(guild=discord.Object(id=cfg.guild_id))
+            logger.info(f"Synced {len(synced)} application commands.")
+
         self.tasks = Tasks(self)
         await init_client_session()
 
@@ -54,10 +66,21 @@ class MyTree(app_commands.CommandTree):
         if interaction.user.bot:
             return False
 
+        command = interaction.command
+
+        if command is not None:
+            root_name = command.root_parent.name if command.root_parent else command.name
+            settings_path = Path(os.environ.get("GIR_COMMUNITY_FILE", str(Path("data/community.json"))))
+            try:
+                disabled = set(json.loads(settings_path.read_text()).get("disabledCommands", []))
+            except (OSError, ValueError, TypeError):
+                disabled = set()
+            if root_name in disabled and interaction.user.id != cfg.owner_id:
+                await interaction.response.send_message("That command is currently turned off for this server.", ephemeral=True)
+                return False
+
         if gatekeeper.has(interaction.user.guild, interaction.user, 6):
             return True
-
-        command = interaction.command
 
         if isinstance(interaction.command, discord.app_commands.ContextMenu):
             return True
@@ -110,7 +133,17 @@ async def app_command_error(interaction: discord.Interaction, error: AppCommandE
         error = error.original
 
     if isinstance(error, discord.errors.NotFound):
-        await ctx.channel.send(embed=discord.Embed(color=discord.Color.red(), title=":(\nYour command ran into a problem.", description=f"Sorry {interaction.user.mention}, it looks like I took too long to respond to you! If I didn't do what you wanted in time, please try again."), delete_after=7)
+        try:
+            await ctx.send_error("Discord says this command took too long. Please try it once more.", whisper=True)
+        except discord.HTTPException:
+            pass
+        return
+
+    if isinstance(error, discord.Forbidden):
+        logger.error(f"Discord denied command {getattr(interaction.command, 'qualified_name', 'unknown')}: {error}")
+        await ctx.send_error(
+            "Discord blocked that action. GIR has its moderation permission, but its role may be below the selected member's role. Ask the server owner to move GIR higher in Server Settings → Roles.",
+            followup=True, whisper=True)
         return
 
     if (isinstance(error, commands.MissingRequiredArgument)
@@ -124,19 +157,14 @@ async def app_command_error(interaction: discord.Interaction, error: AppCommandE
             or isinstance(error, commands.NoPrivateMessage)):
         await ctx.send_error(error, followup=True, whisper=True, delete_after=5)
     else:
+        reference = uuid.uuid4().hex[:8]
+        logger.error(f"Command error reference {reference}\n{''.join(traceback.format_exception(type(error), error, error.__traceback__))}")
         try:
-            raise error
-        except:
-            tb = traceback.format_exc()
-            logger.error(tb)
-            if len(tb.split('\n')) > 8:
-                tb = '\n'.join(tb.split('\n')[-8:])
-
-            tb_formatted = tb
-            if len(tb_formatted) > 1000:
-                tb_formatted = "...\n" + tb_formatted[-1000:]
-
-            await ctx.send_error(description=f"`{error}`\n```{tb_formatted}```", followup=True, whisper=True, delete_after=5)
+            await ctx.send_error(
+                description=f"Something unexpected happened. The private server log has reference `{reference}`.",
+                followup=True, whisper=True)
+        except discord.HTTPException:
+            logger.error(f"Could not deliver command error reference {reference} to Discord")
 
 
 @bot.event
@@ -166,4 +194,5 @@ async def main():
     async with bot:
         await bot.start(os.environ.get("GIR_TOKEN"), reconnect=True)
 
-asyncio.run(main())
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_command_registry.py
+++ b/tests/test_command_registry.py
@@ -1,0 +1,49 @@
+import ast
+import unittest
+from collections import Counter
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def slash_command_names():
+    names = []
+    for source in (ROOT / "cogs").rglob("*.py"):
+        if source.name.startswith("._"):
+            continue
+        tree = ast.parse(source.read_text(encoding="utf-8"), filename=str(source))
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            for decorator in node.decorator_list:
+                if not isinstance(decorator, ast.Call) or not isinstance(decorator.func, ast.Attribute):
+                    continue
+                owner = decorator.func.value
+                if not (isinstance(owner, ast.Name) and owner.id == "app_commands" and decorator.func.attr == "command"):
+                    continue
+                explicit_name = next(
+                    (kw.value.value for kw in decorator.keywords if kw.arg == "name" and isinstance(kw.value, ast.Constant)),
+                    None,
+                )
+                names.append(explicit_name or node.name)
+    return names
+
+
+class CommandRegistryTests(unittest.TestCase):
+    def test_top_level_slash_names_are_unique(self):
+        names = slash_command_names()
+        duplicates = sorted(name for name, count in Counter(names).items() if count > 1)
+        self.assertEqual(duplicates, [])
+
+    def test_overlapping_commands_are_consolidated(self):
+        names = set(slash_command_names())
+        self.assertTrue({"avatar", "serverinfo", "announce", "kick"}.issubset(names))
+        self.assertTrue({"pfp", "membercount", "embed", "roblox"}.isdisjoint(names))
+
+    def test_registry_stays_below_discord_limit(self):
+        self.assertLessEqual(len(slash_command_names()), 100)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_community_rules.py
+++ b/tests/test_community_rules.py
@@ -1,0 +1,26 @@
+import unittest
+
+from community_rules import caps_percent, has_invite, is_image_attachment, recent_count
+
+
+class CommunityRuleTests(unittest.TestCase):
+    def test_caps_ignores_numbers_and_punctuation(self):
+        self.assertEqual(caps_percent("THIS is 123!"), 67)
+        self.assertEqual(caps_percent("123!"), 0)
+
+    def test_discord_invites_are_detected(self):
+        self.assertTrue(has_invite("join https://discord.gg/example"))
+        self.assertTrue(has_invite("DISCORD.COM/invite/example"))
+        self.assertFalse(has_invite("https://example.com"))
+
+    def test_only_events_inside_window_count(self):
+        self.assertEqual(recent_count([80, 91, 95, 100], 100, 10), 3)
+
+    def test_image_attachment_recognizes_mime_and_filename_fallback(self):
+        self.assertTrue(is_image_attachment("image/png", "upload.bin"))
+        self.assertTrue(is_image_attachment(None, "Screenshot.HEIC"))
+        self.assertFalse(is_image_attachment("application/pdf", "statement.pdf"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/context.py
+++ b/utils/context.py
@@ -214,7 +214,7 @@ class GIRContext:
 
         embed = discord.Embed(
             title=title, description=description,  color=discord.Color.red())
-        embed.set_footer(text="Note: The bot maintainer will be pinged about this error automatically.")
+        embed.set_footer(text="Technical details are kept in the private server log.")
         return await self.respond_or_edit(content="", embed=embed, ephemeral=self.whisper or whisper, view=discord.utils.MISSING, delete_after=delete_after, followup=followup)
 
     async def prompt(self, info: PromptData):

--- a/utils/framework/permissions.py
+++ b/utils/framework/permissions.py
@@ -28,22 +28,6 @@ class Permissions:
             
         """
 
-        roles_to_check = [
-            "member_plus",
-            "member_pro",
-            "member_edition",
-            "genius",
-            "moderator",
-            "administrator",
-        ]
-
-        for role in roles_to_check:
-            try:
-                getattr(cfg.roles, role)
-            except AttributeError:
-                raise AttributeError(
-                    f"Database is not set up properly! Role '{role}' is missing. Please refer to README.md.")
-
         self._permission_mapping = {
             1: cfg.roles.member_plus,
             2: cfg.roles.member_pro,
@@ -71,10 +55,10 @@ class Permissions:
                 and guild.get_role(cfg.roles.genius) in m.roles)),
 
             5: (lambda guild, m: self.has(guild, m, 6) or (guild.id == cfg.guild_id
-                and guild.get_role(cfg.roles.moderator) in m.roles)),
+                and (m.guild_permissions.manage_messages or self._has_mapped_role(m, "moderator")))),
 
             6: (lambda guild, m: self.has(guild, m, 7) or (guild.id == cfg.guild_id
-                and guild.get_role(cfg.roles.administrator) in m.roles)),
+                and (m.guild_permissions.administrator or self._has_mapped_role(m, "administrator")))),
 
             7: (lambda guild, m: self.has(guild, m, 9) or (guild.id == cfg.guild_id
                 and m == guild.owner)),
@@ -94,10 +78,19 @@ class Permissions:
             4: "Geniuses and up",
             5: "Moderators and up",
             6: "Administrators and up",
-            7: "Guild owner (Aaron) and up",
+            7: "Guild owner and up",
             9: "Bot owner",
             10: "Bot owner",
         }
+
+    @staticmethod
+    def _has_mapped_role(member: discord.Member, prefix: str) -> bool:
+        """Match the main role alias and any server-specific aliases."""
+        mapped = {
+            int(value) for key, value in vars(cfg.roles).items()
+            if (key == prefix or key.startswith(prefix + "_")) and str(value).isdigit()
+        }
+        return any(role.id in mapped for role in member.roles)
 
     @property
     def lowest_level(self) -> int:

--- a/utils/framework/transformers.py
+++ b/utils/framework/transformers.py
@@ -102,6 +102,14 @@ async def check_invokee(interaction: discord.Interaction, user: discord.Member):
         if user.id == interaction.client.user.id:
             raise PermissionsFailure("You can't call that on me :(")
 
+        if user.id == interaction.guild.owner_id:
+            raise PermissionsFailure("Discord does not allow bots to moderate the server owner.")
+
+        bot_member = interaction.guild.me
+        if bot_member is not None and user.top_role >= bot_member.top_role:
+            raise PermissionsFailure(
+                "Discord's role order blocks that action. In Server Settings → Roles, move GIR above this member's highest role.")
+
         if user:
             if user.top_role >= interaction.user.top_role:
                 raise PermissionsFailure(

--- a/utils/jobs.py
+++ b/utils/jobs.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import random
 from datetime import datetime, timedelta
@@ -53,7 +54,8 @@ class Tasks():
             }
 
         self.tasks = AsyncIOScheduler(
-            jobstores=jobstores, executors=executors, job_defaults=job_defaults, event_loop=bot.loop, timezone=utc)
+            jobstores=jobstores, executors=executors, job_defaults=job_defaults,
+            event_loop=asyncio.get_running_loop(), timezone=utc)
         self.tasks.start()
 
     def schedule_untimeout(self, _id: int, date: datetime) -> None:


### PR DESCRIPTION
## Problem and resulting behavior

GIR's existing r/Jailbreak features remain intact, while this adds an optional general-purpose community layer for servers that need modern moderation, engagement, expression management, free-game discovery, and fast Apple signing checks.

Examples:

- A user below Member+ posts four images in one message: GIR deletes the post, applies a seven-day timeout, and sends a review card with **Ban** and **Dismiss** controls to `#reports`.
- A member asks whether a particular iOS version is signed for a normal device name or identifier: `/tss check` uses the small IPSW.me firmware catalog, returns a real result under a 25-second deadline, and never downloads an IPSW.
- A configured free-game check queries GamerPower, Epic, and CheapShark concurrently, deduplicates results, and posts store-style embeds.

## Included

- Community tools: AutoMod, welcome/goodbye, autoroles, starboard, suggestions, AFK, polls, movie nights, custom commands, automatic replies, reaction roles, and engagement commands.
- Moderator tools: image-spam review cards, channel/role/permission inventory, slow mode, reports, announcements, nickname tools, and safer hierarchy checks.
- Expression tools: emoji and sticker inventory, creation, copying, deletion, and ZIP import/export.
- Game discovery: direct, keyless GamerPower, Epic Games Store, and CheapShark integrations with filters, source health, manual checks, previews, and persistent deduplication.
- Apple tools: device autocomplete, compatible-version lookup, signing status, direct event links, exact-family matching, cache use, and bounded network timeouts.
- Runtime improvements: optional feature-file selection, automatic guild command sync, current-event-loop scheduler setup, safer public errors with private reference IDs, Discord permission diagnostics, and command-registry regression tests.
- `/avatar` can look up a public profile picture by numeric Discord ID.
- Duplicate top-level commands are consolidated to keep the registry within Discord's 100-command limit.

## Compatibility and setup

- Based directly on current `DiscordGIR/GIRRewrite:main` (`dd9644b`).
- All original jailbreak extensions still load by default.
- Uses the existing requirements; no new package or paid API key is required.
- Python paths default to repository-relative `data/` files and remain portable across Docker, Linux, macOS, and Windows.
- Optional variables are documented in `.env.example` and README: `GIR_COMMUNITY_FILE`, `GIR_FEATURE_FILE`, `GIR_SYNC_COMMANDS`, and `TSSCHECKER_PATH`.
- Configure the existing Member+, moderator, and administrator role mappings and the reports channel during normal setup.
- Enable Server Members and Message Content privileged intents. Grant only the permissions needed by enabled features: Manage Messages, Moderate Members, Ban Members, Manage Roles, Manage Expressions, and View Audit Log. GIR's role must be above roles it moderates.
- Automatic background actions start disabled in `data/community.json` until an operator configures them.

## External services and credit

GamerPower, Epic Games Store, CheapShark, and IPSW.me are called through their public endpoints and credited in the README. FreeStuff was reviewed only as a product reference; no GPL source was copied. RSS and feed-scraping integrations are excluded.

## Validation

- `PYTHONPATH=. python3 -m unittest discover -s tests -p 'test_*.py'` — 7 passed
- Compiled every Python file under `cogs/`, `utils/`, and `tests/`, plus `main.py`, `extensions.py`, and `community_rules.py`
- `git diff --check`
- Live validation on discord.py 2.7.1: 99 registered application commands, successful startup, direct-provider game checks, TSS response under one second, and moderation/dashboard permission readiness
