### PR TITLE
Add server-aware moderation, automation, Apple, games, and music suites

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,11 @@ DB_PORT=27017 # Whatever port Mongo is running on. 27017 is the default.
 # DELETE THE LINE, don't set it to False.
 DEV=True
 
+# optional: directory for dashboard settings and generated command metadata.
+# Defaults to ~/.gir/data on every supported operating system.
+GIR_DATA_DIR=""
+# GIR_COMMUNITY_FILE and GIR_FEATURE_FILE may override individual files instead.
+
 # this is optional, if you want ban appeal form support. 
 # delete this section if you don't want it.
 BAN_APPEAL_URL="" # link to the ban appeal form
@@ -34,4 +39,4 @@ RESNEXT_TOKEN="your token here"
 
 # optional
 # enable /memegen text and /memegen aipfp commands
-# ENABLE_MARKOV=True 
+# ENABLE_MARKOV=True

--- a/.gitignore
+++ b/.gitignore
@@ -125,6 +125,7 @@ dmypy.json
 
 # macOS files
 .DS_Store
+._*
 
 # PyCharm files
 .idea/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # GIR Rewrite
+
+> This file preserves the upstream project history and original cross-platform setup notes. For the current dashboard, production features, hosting choices, and live command reference, start with the repository-level documentation.
+
 ![GIR banner](data/images/banner.png)
 
 GIR is a sophisticated moderation and miscellaneous utilities Discord bot created for the [r/Jailbreak Discord server](https://reddit.com/r/jailbreak). It features:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 > This file preserves the upstream project history and original cross-platform setup notes. For the current dashboard, production features, hosting choices, and live command reference, start with the repository-level documentation.
 
+Dashboard-managed runtime files default to `~/.gir/data` on Linux, macOS, and Windows. Set `GIR_DATA_DIR` to use another directory, or set `GIR_COMMUNITY_FILE` and `GIR_FEATURE_FILE` for individual file locations.
+
 ![GIR banner](data/images/banner.png)
 
 GIR is a sophisticated moderation and miscellaneous utilities Discord bot created for the [r/Jailbreak Discord server](https://reddit.com/r/jailbreak). It features:

--- a/cogs/commands/context_commands.py
+++ b/cogs/commands/context_commands.py
@@ -139,19 +139,13 @@ def setup_context_commands(bot: commands.Bot):
         await manual_report(ctx.author, member, urgent)
         await ctx.send_success("Generated report!")
 
-    @genius_and_up()
-    @bot.tree.context_menu(guild=discord.Object(id=cfg.guild_id), name="Generate report")
+    @bot.tree.context_menu(guild=discord.Object(id=cfg.guild_id), name="Report message")
     async def generate_report_msg(interaction: discord.Interaction, message: discord.Message) -> None:
-        ctx = GIRContext(interaction)
-        ctx.whisper = True
-
-        view = Confirm(ctx, true_response="Sending report with ping!", false_response="Sending report without ping!")
-        await ctx.respond("Is this report worth pinging moderators over?", view=view, ephemeral=True)
-        await view.wait()
-        urgent  = view.value
-
-        await manual_report(ctx.author, message, urgent)
-        await ctx.send_success("Generated report!")
+        suite = bot.get_cog("CommunitySuite")
+        if suite is None:
+            await interaction.response.send_message("Message reporting is temporarily unavailable.", ephemeral=True)
+            return
+        await suite.report_message(interaction, message)
 
     @bot.tree.context_menu(guild=discord.Object(id=cfg.guild_id), name="Userinfo")
     async def userinfo_rc(interaction: discord.Interaction, user: discord.Member) -> None:

--- a/cogs/commands/misc/misc.py
+++ b/cogs/commands/misc/misc.py
@@ -141,11 +141,28 @@ class Misc(commands.Cog):
             await give_user_birthday_role(self.bot, ctx.author, ctx.guild)
 
     @app_commands.guilds(cfg.guild_id)
-    @app_commands.command(description="Get avatar of another user or yourself.")
-    @app_commands.describe(user="The user you want to get the avatar of")
+    @app_commands.command(description="Get a Discord user's profile picture.")
+    @app_commands.describe(
+        user="A member or user Discord can suggest",
+        discord_id="A numeric Discord user ID, including someone outside this server",
+    )
     @transform_context
     @whisper
-    async def avatar(self, ctx: GIRContext, user: Union[discord.Member, discord.User] = None) -> None:
+    async def avatar(
+        self,
+        ctx: GIRContext,
+        user: Union[discord.Member, discord.User] = None,
+        discord_id: str = None,
+    ) -> None:
+        if user is not None and discord_id is not None:
+            raise commands.BadArgument("Choose a user or enter a Discord ID, not both.")
+        if discord_id is not None:
+            if not discord_id.isdigit():
+                raise commands.BadArgument("Enter a numeric Discord user ID.")
+            try:
+                user = await self.bot.fetch_user(int(discord_id))
+            except (discord.NotFound, discord.HTTPException):
+                raise commands.BadArgument("I could not find that Discord user.")
         if user is None:
             user = ctx.author
 

--- a/cogs/commands/mod/modactions.py
+++ b/cogs/commands/mod/modactions.py
@@ -60,25 +60,6 @@ class ModActions(commands.Cog):
 
     @mod_and_up()
     @app_commands.guilds(cfg.guild_id)
-    @app_commands.command(description="Kick a user")
-    @app_commands.describe(member="User to kick")
-    @transform_context
-    async def roblox(self, ctx: GIRContext, member: ModsAndAboveMember) -> None:
-        reason = "This Discord server is for iOS jailbreaking, not Roblox. Please join https://discord.gg/jailbreak instead, thank you!"
-
-        db_guild = guild_service.get_guild()
-
-        log = add_kick_case(target_member=member, mod=ctx.author, reason=reason, db_guild=db_guild)
-        await notify_user(member, f"You were kicked from {ctx.guild.name}", log)
-
-        await ctx.defer(ephemeral=False)
-        await member.kick(reason=reason)
-
-        await ctx.respond_or_edit(embed=log, delete_after=10)
-        await submit_public_log(ctx, member, log)
-
-    @mod_and_up()
-    @app_commands.guilds(cfg.guild_id)
     @app_commands.command(description="Mute a user")
     @app_commands.describe(member="User to mute")
     @app_commands.describe(duration="Duration of the mute (i.e 10m, 1h, 1d...)")
@@ -424,7 +405,7 @@ class ModActions(commands.Cog):
 
     @mod_and_up()
     @app_commands.guilds(cfg.guild_id)
-    @app_commands.command(description="Edit case reason")
+    @app_commands.command(description="Remove warning points from a member")
     @app_commands.describe(member="Member to remove points from")
     @app_commands.describe(points="Amount of points to remove")
     @app_commands.describe(reason="Reason for removing points")

--- a/cogs/commands/mod/modactions.py
+++ b/cogs/commands/mod/modactions.py
@@ -60,6 +60,21 @@ class ModActions(commands.Cog):
 
     @mod_and_up()
     @app_commands.guilds(cfg.guild_id)
+    @app_commands.command(description="Kick a user for posting Roblox content")
+    @app_commands.describe(member="User to kick")
+    @transform_context
+    async def roblox(self, ctx: GIRContext, member: ModsAndAboveMember) -> None:
+        reason = "This Discord server is for iOS jailbreaking, not Roblox. Please join https://discord.gg/jailbreak instead, thank you!"
+        db_guild = guild_service.get_guild()
+        log = add_kick_case(target_member=member, mod=ctx.author, reason=reason, db_guild=db_guild)
+        await notify_user(member, f"You were kicked from {ctx.guild.name}", log)
+        await ctx.defer(ephemeral=False)
+        await member.kick(reason=reason)
+        await ctx.respond_or_edit(embed=log, delete_after=10)
+        await submit_public_log(ctx, member, log)
+
+    @mod_and_up()
+    @app_commands.guilds(cfg.guild_id)
     @app_commands.command(description="Mute a user")
     @app_commands.describe(member="User to mute")
     @app_commands.describe(duration="Duration of the mute (i.e 10m, 1h, 1d...)")
@@ -217,7 +232,9 @@ class ModActions(commands.Cog):
             return
 
         self.bot.ban_cache.ban(user.id)
-        log = await add_ban_case(user, ctx.author, reason, db_guild)
+        # Attribute the stored case to the second moderator who approved it.
+        # Public logs remain anonymous as "Server Staff" below.
+        log = await add_ban_case(user, view.confirming_mod, reason, db_guild)
 
         log.set_field_at(1, name="Mod", value=f"{ctx.guild.name} Staff")
 

--- a/cogs/community_suite.py
+++ b/cogs/community_suite.py
@@ -6,6 +6,7 @@ actions start disabled, and every automatic action can be reviewed in Discord.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import os
 import random

--- a/cogs/community_suite.py
+++ b/cogs/community_suite.py
@@ -55,7 +55,6 @@ DEFAULTS = {
     "movieNight": {"enabled": False, "channelID": 0, "pingRoleID": 0},
     "relay": {"enabled": False, "destinationGuildID": 0, "messages": True, "edits": True,
               "deletes": True, "reactions": True, "channelRoutes": []},
-    "appleEvents": {"enabled": False, "channelID": 0, "roleID": 0},
     "customCommands": [], "autoResponses": [], "reactionRoles": [], "disabledCommands": [],
 }
 

--- a/cogs/community_suite.py
+++ b/cogs/community_suite.py
@@ -13,7 +13,7 @@ import re
 import zipfile
 from io import BytesIO
 import time
-from urllib.parse import quote
+from urllib.parse import quote, urlparse
 from collections import defaultdict, deque
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -37,6 +37,10 @@ GAME_REQUEST_FILE = DATA_FILE.with_name("free-games-request.json")
 GAME_API = "https://www.gamerpower.com/api/giveaways"
 EPIC_API = "https://store-site-backend-static.ak.epicgames.com/freeGamesPromotions?locale=en-US&country=US&allowCountries=US"
 CHEAPSHARK_API = "https://www.cheapshark.com/api/1.0/deals?upperPrice=0&onSale=1&pageSize=60&sortBy=Recent"
+DEFAULT_GAME_FEEDS = [
+    "https://www.reddit.com/r/FreeGameFindings+FreeGamesOnSteam+GameDeals/.rss?limit=75",
+    "https://www.gamerpower.com/rss/pc",
+]
 
 DEFAULTS = {
     "automod": {
@@ -51,7 +55,7 @@ DEFAULTS = {
     "autorole": {"enabled": False, "roleIDs": []},
     "starboard": {"enabled": False, "channelID": 0, "threshold": 3, "emoji": "⭐"},
     "suggestions": {"enabled": False, "channelID": 0},
-    "freeGames": {"enabled": False, "channelID": 0, "platforms": ["pc", "steam", "epic-games-store", "ps4", "ps5", "xbox-one", "xbox-series-xs"], "types": ["game"], "sources": ["gamerpower", "epic", "cheapshark"], "checkMinutes": 15, "pingRoleID": 0, "minimumWorth": 0, "hideUnrated": False, "includeExpired": False, "maxPostsPerCheck": 5},
+    "freeGames": {"enabled": False, "channelID": 0, "platforms": ["pc", "steam", "epic-games-store", "ps4", "ps5", "xbox-one", "xbox-series-xs"], "types": ["game"], "sources": ["gamerpower", "epic", "cheapshark", "communityFeeds"], "communityFeedURLs": DEFAULT_GAME_FEEDS, "twitterAccounts": ["EpicGames", "GamerPowercom", "FreeGameFinding", "just_free_games"], "twitterBridge": "https://rsshub.app", "checkMinutes": 15, "pingRoleID": 0, "minimumWorth": 0, "hideUnrated": False, "includeExpired": False, "maxPostsPerCheck": 5},
     "movieNight": {"enabled": False, "channelID": 0, "pingRoleID": 0},
     "relay": {"enabled": False, "destinationGuildID": 0, "messages": True, "edits": True,
               "deletes": True, "reactions": True, "channelRoutes": []},
@@ -165,6 +169,39 @@ class CommunitySuite(commands.Cog):
             logger.warning("Free-game provider %s failed: %s", name, error)
             return name, error
 
+    async def _fetch_game_feed(self, session, name, url):
+        try:
+            async with session.get(url, timeout=aiohttp.ClientTimeout(total=20)) as response:
+                response.raise_for_status(); root = ET.fromstring(await response.text())
+            games = []
+            for node in list(root.findall(".//item"))[:40] + list(root.findall("{*}entry"))[:40]:
+                def value(*tags):
+                    for tag in tags:
+                        child = node.find(tag)
+                        if child is not None:
+                            return child.get("href") or child.text or ""
+                    return ""
+                title = re.sub(r"<[^>]+>", "", value("title", "{*}title")).strip()
+                detail = re.sub(r"<[^>]+>", "", value("description", "{*}summary", "{*}content")).strip()
+                searchable = (title + " " + detail).lower()
+                category = node.find("{*}category")
+                subreddit = str(category.get("term", "")) if category is not None else ""
+                if (subreddit.lower() == "gamedeals" or name == "Reddit GameDeals" or name.startswith("X @")) and not re.search(r"\b(free|100% off|0\.00|giveaway)\b", searchable):
+                    continue
+                link = value("link", "{*}link")
+                identifier = value("guid", "{*}id") or link or title
+                platform = ("Steam, PC" if "steam" in searchable else "Epic Games Store, PC" if "epic" in searchable
+                            else "PlayStation 5, PlayStation 4" if re.search(r"\b(ps5|ps4|playstation)\b", searchable)
+                            else "Xbox Series X/S, Xbox One" if "xbox" in searchable else "Nintendo Switch" if "switch" in searchable else "PC")
+                offer_type = "loot" if re.search(r"\b(dlc|pack|loot|skin|key)\b", searchable) else "game"
+                games.append({"id": f"feed:{hashlib.sha256(identifier.encode()).hexdigest()}", "title": title,
+                    "description": detail[:900], "platforms": platform, "type": offer_type, "worth": "Unknown",
+                    "end_date": None, "open_giveaway_url": link, "source": f"Reddit r/{subreddit}" if subreddit else name, "source_url": url})
+            return name, games
+        except (aiohttp.ClientError, asyncio.TimeoutError, ValueError, ET.ParseError) as error:
+            logger.warning("Free-game feed %s failed: %s", name, error)
+            return name, error
+
     @staticmethod
     def _epic_games(payload):
         rows = payload.get("data", {}).get("Catalog", {}).get("searchStore", {}).get("elements", [])
@@ -217,10 +254,25 @@ class CommunitySuite(commands.Cog):
                 return None
 
     async def fetch_free_games(self, settings=None):
-        enabled = set((settings or {}).get("sources") or ["gamerpower", "epic", "cheapshark"])
+        settings = settings or {}
+        enabled = set(settings.get("sources") or ["gamerpower", "epic", "cheapshark", "communityFeeds"])
         urls = {"gamerpower": GAME_API + "?sort-by=date", "epic": EPIC_API, "cheapshark": CHEAPSHARK_API}
         async with aiohttp.ClientSession(headers={"User-Agent": "GIR Discord Bot/1.0"}) as session:
             results = await asyncio.gather(*(self._fetch_json(session, name, url) for name, url in urls.items() if name in enabled))
+            feed_jobs = []
+            if "communityFeeds" in enabled:
+                for url in settings.get("communityFeedURLs") or DEFAULT_GAME_FEEDS:
+                    if "FreeGameFindings+" in url: name = "Reddit free-game communities"
+                    elif "FreeGameFindings" in url: name = "Reddit FreeGameFindings"
+                    elif "FreeGamesOnSteam" in url: name = "Reddit FreeGamesOnSteam"
+                    elif "GameDeals" in url: name = "Reddit GameDeals"
+                    elif "gamerpower.com" in url: name = "GamerPower RSS"
+                    else: name = urlparse(url).hostname or "Community feed"
+                    feed_jobs.append(self._fetch_game_feed(session, name, url))
+                bridge = str(settings.get("twitterBridge") or "https://rsshub.app").rstrip("/")
+                for account in settings.get("twitterAccounts") or []:
+                    feed_jobs.append(self._fetch_game_feed(session, f"X @{account}", f"{bridge}/twitter/user/{quote(str(account).lstrip('@'))}"))
+            feed_results = await asyncio.gather(*feed_jobs)
         games = []
         for name, payload in results:
             if isinstance(payload, Exception):
@@ -234,6 +286,11 @@ class CommunitySuite(commands.Cog):
                 games.extend(self._epic_games(payload))
             elif name == "cheapshark":
                 games.extend(self._cheapshark_games(payload))
+        for name, payload in feed_results:
+            if isinstance(payload, Exception):
+                self.game_provider_health[name] = "Unavailable"
+            else:
+                self.game_provider_health[name] = f"OK · {len(payload)} matches"; games.extend(payload)
         return self._dedupe_games(games)
 
     def filtered_games(self, games, settings):

--- a/cogs/community_suite.py
+++ b/cogs/community_suite.py
@@ -36,7 +36,7 @@ GAME_STATUS_FILE = DATA_FILE.with_name("free-games-status.json")
 GAME_REQUEST_FILE = DATA_FILE.with_name("free-games-request.json")
 GAME_API = "https://www.gamerpower.com/api/giveaways"
 EPIC_API = "https://store-site-backend-static.ak.epicgames.com/freeGamesPromotions?locale=en-US&country=US&allowCountries=US"
-CHEAPSHARK_API = "https://www.cheapshark.com/api/1.0/deals?upperPrice=0&onSale=1&pageSize=60&sortBy=Recent"
+CHEAPSHARK_API = "https://www.cheapshark.com/api/1.0/deals?onSale=1&pageSize=60&sortBy=Savings"
 DEFAULT_GAME_FEEDS = [
     "https://www.reddit.com/r/FreeGameFindings+FreeGamesOnSteam+GameDeals/.rss?limit=75",
     "https://www.gamerpower.com/rss/pc",
@@ -55,7 +55,7 @@ DEFAULTS = {
     "autorole": {"enabled": False, "roleIDs": []},
     "starboard": {"enabled": False, "channelID": 0, "threshold": 3, "emoji": "⭐"},
     "suggestions": {"enabled": False, "channelID": 0},
-    "freeGames": {"enabled": False, "channelID": 0, "platforms": ["pc", "steam", "epic-games-store", "ps4", "ps5", "xbox-one", "xbox-series-xs"], "types": ["game"], "sources": ["gamerpower", "epic", "cheapshark", "communityFeeds"], "communityFeedURLs": DEFAULT_GAME_FEEDS, "twitterAccounts": ["EpicGames", "GamerPowercom", "FreeGameFinding", "just_free_games"], "twitterBridge": "https://rsshub.app", "checkMinutes": 15, "pingRoleID": 0, "minimumWorth": 0, "hideUnrated": False, "includeExpired": False, "maxPostsPerCheck": 5},
+    "freeGames": {"enabled": False, "channelID": 0, "platforms": ["pc", "steam", "epic-games-store", "ps4", "ps5", "xbox-one", "xbox-series-xs"], "types": ["game"], "sources": ["gamerpower", "epic", "cheapshark", "communityFeeds"], "communityFeedURLs": DEFAULT_GAME_FEEDS, "twitterAccounts": ["EpicGames", "GamerPowercom", "FreeGameFinding", "just_free_games", "CDKeys_com", "G2A_com"], "twitterBridge": "https://rsshub.app", "offerMode": "both", "minimumDiscountPercent": 50, "checkMinutes": 15, "pingRoleID": 0, "minimumWorth": 0, "hideUnrated": False, "includeExpired": False, "maxPostsPerCheck": 5},
     "movieNight": {"enabled": False, "channelID": 0, "pingRoleID": 0},
     "relay": {"enabled": False, "destinationGuildID": 0, "messages": True, "edits": True,
               "deletes": True, "reactions": True, "channelRoutes": []},
@@ -186,7 +186,7 @@ class CommunitySuite(commands.Cog):
                 searchable = (title + " " + detail).lower()
                 category = node.find("{*}category")
                 subreddit = str(category.get("term", "")) if category is not None else ""
-                if (subreddit.lower() == "gamedeals" or name == "Reddit GameDeals" or name.startswith("X @")) and not re.search(r"\b(free|100% off|0\.00|giveaway)\b", searchable):
+                if (subreddit.lower() == "gamedeals" or name == "Reddit GameDeals" or name.startswith("X @")) and not re.search(r"\b(free|giveaway|sale|deal|discount|save)\b|\d+% off|\$0\.00", searchable):
                     continue
                 link = value("link", "{*}link")
                 identifier = value("guid", "{*}id") or link or title
@@ -194,8 +194,11 @@ class CommunitySuite(commands.Cog):
                             else "PlayStation 5, PlayStation 4" if re.search(r"\b(ps5|ps4|playstation)\b", searchable)
                             else "Xbox Series X/S, Xbox One" if "xbox" in searchable else "Nintendo Switch" if "switch" in searchable else "PC")
                 offer_type = "loot" if re.search(r"\b(dlc|pack|loot|skin|key)\b", searchable) else "game"
+                percent = re.search(r"(\d{1,3})%\s*off", searchable)
                 games.append({"id": f"feed:{hashlib.sha256(identifier.encode()).hexdigest()}", "title": title,
                     "description": detail[:900], "platforms": platform, "type": offer_type, "worth": "Unknown",
+                    "salePrice": 0 if re.search(r"\b(free|giveaway)\b|\$0\.00|100% off", searchable) else None,
+                    "discountPercent": int(percent.group(1)) if percent else 0,
                     "end_date": None, "open_giveaway_url": link, "source": f"Reddit r/{subreddit}" if subreddit else name, "source_url": url})
             return name, games
         except (aiohttp.ClientError, asyncio.TimeoutError, ValueError, ET.ParseError) as error:
@@ -225,12 +228,13 @@ class CommunitySuite(commands.Cog):
 
     @staticmethod
     def _cheapshark_games(rows):
-        return [{"id": f"cheapshark:{row.get('dealID')}", "title": row.get("title"), "description": "A store deal currently listed at no cost.",
+        return [{"id": f"cheapshark:{row.get('dealID')}", "title": row.get("title"), "description": f"Discounted from ${float(row.get('normalPrice') or 0):.2f} to ${float(row.get('salePrice') or 0):.2f}.",
                  "platforms": "PC", "type": "game", "worth": f"${float(row.get('normalPrice') or 0):.2f}",
+                 "salePrice": float(row.get("salePrice") or 0), "discountPercent": float(row.get("savings") or 0),
                  "end_date": None, "thumbnail": row.get("thumb"),
                  "open_giveaway_url": f"https://www.cheapshark.com/redirect?dealID={quote(str(row.get('dealID') or ''), safe='')}",
                  "source": "CheapShark", "source_url": "https://www.cheapshark.com/"}
-                for row in rows if float(row.get("salePrice") or 1) == 0]
+                for row in rows]
 
     @staticmethod
     def _dedupe_games(games):
@@ -298,6 +302,7 @@ class CommunitySuite(commands.Cog):
         types = {str(value).lower() for value in settings.get("types", [])}
         minimum_worth = max(0.0, float(settings.get("minimumWorth", 0) or 0))
         now = datetime.now(timezone.utc)
+        offer_mode = str(settings.get("offerMode", "both")); minimum_discount = float(settings.get("minimumDiscountPercent", 50) or 0)
 
         def worth(game):
             match = re.search(r"\d+(?:\.\d+)?", str(game.get("worth") or "0").replace(",", ""))
@@ -308,6 +313,13 @@ class CommunitySuite(commands.Cog):
                 return True
             end = self._game_date(game["end_date"])
             return end is None or end > now
+
+        def offer_matches(game):
+            source = str(game.get("source", "")).lower()
+            text = " ".join(str(game.get(key, "")) for key in ("title", "description")).lower()
+            free = game.get("salePrice") == 0 or source in {"gamerpower", "epic games store", "gamerpower rss"} or "freegamefindings" in source or "freegamesonsteam" in source or bool(re.search(r"\b(free|giveaway)\b|\$0\.00|100% off", text))
+            discounted = float(game.get("discountPercent") or 0) >= minimum_discount
+            return free if offer_mode == "free" else discounted and not free if offer_mode == "discounts" else free or discounted
 
         aliases = {"epic-games-store": "epic games store", "ps4": "playstation 4", "ps5": "playstation 5",
                    "xbox-one": "xbox one", "xbox-series-xs": "xbox series x/s", "itchio": "itch.io"}
@@ -321,6 +333,7 @@ class CommunitySuite(commands.Cog):
                 and (not types or str(game.get("type", "")).lower() in types)
                 and worth(game) >= minimum_worth
                 and (not settings.get("hideUnrated") or worth(game) > 0)
+                and offer_matches(game)
                 and active(game)]
 
     @tasks.loop(minutes=15)
@@ -439,6 +452,8 @@ class CommunitySuite(commands.Cog):
 
     @staticmethod
     def _claim_kind(game):
+        if game.get("salePrice") is not None and float(game.get("salePrice") or 0) > 0:
+            return f"{float(game.get('discountPercent') or 0):.0f}% off"
         text = " ".join(str(game.get(key, "")) for key in ("title", "description", "instructions")).lower()
         temporary = ("free weekend", "free week", "free to play until", "play for free", "open beta", "playtest")
         return "Free to play" if any(phrase in text for phrase in temporary) else "Free to keep"

--- a/cogs/community_suite.py
+++ b/cogs/community_suite.py
@@ -111,6 +111,7 @@ class CommunitySuite(commands.Cog):
         self.free_game_check.cancel()
         self.free_game_request_check.cancel()
         self.relay_worker.cancel()
+        self.bot.tree.remove_command("Report message", guild=discord.Object(id=cfg.guild_id), type=discord.AppCommandType.message)
 
     def settings(self):
         return load_settings()
@@ -807,8 +808,6 @@ class CommunitySuite(commands.Cog):
         content, mentions = self._report_mentions(interaction.guild)
         await channel.send(content=content, embed=embed, allowed_mentions=mentions); await interaction.response.send_message("Your report was sent privately to the moderators.", ephemeral=True)
 
-    @app_commands.guilds(cfg.guild_id)
-    @app_commands.context_menu(name="Report message")
     async def report_message(self, interaction: discord.Interaction, message: discord.Message):
         if not self._report_access(interaction.user):
             await interaction.response.send_message("You are not in a role allowed to report messages.", ephemeral=True); return
@@ -1082,4 +1081,7 @@ class CommunitySuite(commands.Cog):
 
 
 async def setup(bot):
-    await bot.add_cog(CommunitySuite(bot))
+    cog = CommunitySuite(bot)
+    await bot.add_cog(cog)
+    bot.tree.add_command(app_commands.ContextMenu(name="Report message", callback=cog.report_message),
+                         guild=discord.Object(id=cfg.guild_id))

--- a/cogs/community_suite.py
+++ b/cogs/community_suite.py
@@ -8,14 +8,19 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import random
+import re
+import zipfile
+from io import BytesIO
 import time
 from collections import defaultdict, deque
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import discord
+import aiohttp
 from discord import app_commands
-from discord.ext import commands
+from discord.ext import commands, tasks
 
 from utils import cfg, logger
 from community_rules import caps_percent, has_invite, recent_count
@@ -25,6 +30,8 @@ DATA_FILE = Path(os.environ.get(
     "GIR_COMMUNITY_FILE",
     str(Path.home() / "Library/Application Support/SowensServer/GIRRuntime/dashboard/data/community.json"),
 ))
+GAME_STATE_FILE = DATA_FILE.with_name("free-games-state.json")
+GAME_API = "https://www.gamerpower.com/api/giveaways"
 
 DEFAULTS = {
     "automod": {
@@ -33,13 +40,15 @@ DEFAULTS = {
         "imageWindowSeconds": 20, "fastSpam": True, "messageThreshold": 7,
         "messageWindowSeconds": 8, "capsSpam": True, "capsPercent": 80,
         "mentionSpam": True, "mentionThreshold": 6, "inviteLinks": False,
-        "ignoredChannelIDs": [], "ignoredRoleIDs": [],
+        "monitorAllChannels": True, "monitoredChannelIDs": [], "ignoredChannelIDs": [], "ignoredRoleIDs": [],
     },
     "welcome": {"enabled": False, "channelID": 0, "message": "Welcome {mention} to {server}!", "goodbyeEnabled": False, "goodbyeMessage": "{name} left the server."},
     "autorole": {"enabled": False, "roleIDs": []},
     "starboard": {"enabled": False, "channelID": 0, "threshold": 3, "emoji": "⭐"},
     "suggestions": {"enabled": False, "channelID": 0},
-    "customCommands": [], "autoResponses": [], "reactionRoles": [],
+    "freeGames": {"enabled": False, "channelID": 0, "platforms": ["pc", "steam", "epic-games-store", "ps4", "ps5", "xbox-one", "xbox-series-xs"], "types": ["game"], "pingRoleID": 0},
+    "movieNight": {"enabled": False, "channelID": 0, "pingRoleID": 0},
+    "customCommands": [], "autoResponses": [], "reactionRoles": [], "disabledCommands": [],
 }
 
 
@@ -67,9 +76,69 @@ class CommunitySuite(commands.Cog):
         self.activity = defaultdict(lambda: deque(maxlen=30))
         self.images = defaultdict(lambda: deque(maxlen=30))
         self.star_posts = {}
+        self.afk = {}
+        self.free_game_check.start()
+
+    def cog_unload(self):
+        self.free_game_check.cancel()
 
     def settings(self):
         return load_settings()
+
+    async def fetch_free_games(self):
+        async with aiohttp.ClientSession(headers={"User-Agent": "GIR Discord Bot"}) as session:
+            async with session.get(GAME_API, timeout=20) as response:
+                if response.status == 201:
+                    return []
+                response.raise_for_status()
+                return await response.json()
+
+    def filtered_games(self, games, settings):
+        platforms = {str(value).lower() for value in settings.get("platforms", [])}
+        types = {str(value).lower() for value in settings.get("types", [])}
+        return [game for game in games if (not platforms or any(platform in str(game.get("platforms", "")).lower() for platform in platforms))
+                and (not types or str(game.get("type", "")).lower() in types)]
+
+    @tasks.loop(minutes=15)
+    async def free_game_check(self):
+        settings = self.settings()["freeGames"]
+        if not settings.get("enabled"):
+            return
+        channel = self.bot.get_channel(int(settings.get("channelID") or 0))
+        if not channel:
+            return
+        try:
+            games = self.filtered_games(await self.fetch_free_games(), settings)
+            try:
+                seen = set(json.loads(GAME_STATE_FILE.read_text()).get("seen", []))
+            except (OSError, ValueError, TypeError):
+                seen = {str(game.get("id")) for game in games}
+            for game in reversed([item for item in games if str(item.get("id")) not in seen]):
+                await self.post_game(channel, game, settings)
+            seen.update(str(game.get("id")) for game in games)
+            GAME_STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+            temporary = GAME_STATE_FILE.with_suffix(".tmp")
+            temporary.write_text(json.dumps({"seen": sorted(seen)[-2000:]}) + "\n"); temporary.replace(GAME_STATE_FILE)
+        except Exception:
+            logger.exception("Free game check failed")
+
+    @free_game_check.before_loop
+    async def before_free_game_check(self):
+        await self.bot.wait_until_ready()
+
+    async def post_game(self, channel, game, settings):
+        title = str(game.get("title", "Free game"))[:256]
+        description = str(game.get("description", ""))[:2800]
+        url = game.get("open_giveaway_url") or game.get("gamerpower_url") or "https://www.gamerpower.com/"
+        embed = discord.Embed(title=title, url=url, description=description, color=discord.Color.green())
+        embed.add_field(name="Platforms", value=str(game.get("platforms", "Unknown"))[:1024])
+        embed.add_field(name="Normal price", value=str(game.get("worth") or "Unknown"))
+        embed.add_field(name="Ends", value=str(game.get("end_date") or "While supplies last"))
+        if game.get("image") or game.get("thumbnail"):
+            embed.set_image(url=game.get("image") or game.get("thumbnail"))
+        embed.add_field(name="Source", value="[Giveaway data from GamerPower](https://www.gamerpower.com/)", inline=False)
+        role_id = int(settings.get("pingRoleID") or 0); role = channel.guild.get_role(role_id)
+        await channel.send(content=role.mention if role else None, embed=embed, allowed_mentions=discord.AllowedMentions(roles=True))
 
     @staticmethod
     def _staff(member: discord.Member, settings: dict) -> bool:
@@ -109,6 +178,16 @@ class CommunitySuite(commands.Cog):
         settings = self.settings()
         lowered = message.content.lower().strip()
 
+        if message.author.id in self.afk:
+            self.afk.pop(message.author.id, None)
+            try:
+                await message.channel.send(f"Welcome back, {message.author.mention}. I cleared your AFK status.", delete_after=7)
+            except discord.HTTPException:
+                pass
+        for member in message.mentions:
+            if member.id in self.afk:
+                await message.channel.send(f"{member.display_name} is AFK: {self.afk[member.id]}", reference=message, mention_author=False)
+
         for item in settings.get("customCommands", []):
             if item.get("enabled", True) and lowered == str(item.get("trigger", "")).lower().strip():
                 await message.channel.send(str(item.get("response", ""))[:2000], reference=message, mention_author=False)
@@ -120,7 +199,11 @@ class CommunitySuite(commands.Cog):
                 break
 
         auto = settings["automod"]
-        if not auto.get("enabled") or self._staff(message.author, auto) or message.channel.id in set(auto.get("ignoredChannelIDs", [])):
+        monitored = set(auto.get("monitoredChannelIDs", []))
+        channel_ids = {message.channel.id, getattr(message.channel, "parent_id", 0)}
+        if (not auto.get("enabled") or self._staff(message.author, auto)
+                or channel_ids & set(auto.get("ignoredChannelIDs", []))
+                or (not auto.get("monitorAllChannels", True) and not channel_ids & monitored)):
             return
         now = time.monotonic()
         key = (message.guild.id, message.author.id)
@@ -265,6 +348,227 @@ class CommunitySuite(commands.Cog):
     async def slowmode(self, interaction: discord.Interaction, seconds: app_commands.Range[int, 0, 21600]):
         await interaction.channel.edit(slowmode_delay=seconds, reason=f"Changed by {interaction.user}")
         await interaction.response.send_message("Slow mode turned off." if seconds == 0 else f"Members can now send one message every {seconds} seconds.", ephemeral=True)
+
+    @app_commands.guilds(cfg.guild_id)
+    @app_commands.command(name="report", description="Privately report a member to the moderation team")
+    async def report(self, interaction: discord.Interaction, member: discord.Member, reason: str):
+        channel = interaction.guild.get_channel(int(getattr(cfg.channels, "reports", 0)))
+        if not channel:
+            await interaction.response.send_message("The reports channel is not set up yet.", ephemeral=True); return
+        embed = discord.Embed(title="Member report", description=reason[:4000], color=discord.Color.orange(), timestamp=datetime.now(timezone.utc))
+        embed.add_field(name="Reported member", value=f"{member.mention}\n`{member.id}`")
+        embed.add_field(name="Reported by", value=f"{interaction.user.mention}\n`{interaction.user.id}`")
+        await channel.send(embed=embed); await interaction.response.send_message("Your report was sent privately to the moderators.", ephemeral=True)
+
+    @app_commands.guilds(cfg.guild_id)
+    @app_commands.command(name="afk", description="Let people know you are away")
+    async def afk_command(self, interaction: discord.Interaction, reason: str = "Away for a while"):
+        self.afk[interaction.user.id] = reason[:200]
+        await interaction.response.send_message("Your AFK status is set. It will clear when you send a message.", ephemeral=True)
+
+    @app_commands.guilds(cfg.guild_id)
+    @app_commands.command(name="coinflip", description="Flip a coin")
+    async def coinflip(self, interaction: discord.Interaction):
+        await interaction.response.send_message(random.choice(("Heads 🪙", "Tails 🪙")))
+
+    @app_commands.guilds(cfg.guild_id)
+    @app_commands.command(name="roll", description="Roll dice")
+    async def roll(self, interaction: discord.Interaction, sides: app_commands.Range[int, 2, 1000] = 6):
+        await interaction.response.send_message(f"🎲 You rolled **{random.randint(1, sides)}** out of {sides}.")
+
+    @app_commands.guilds(cfg.guild_id)
+    @app_commands.command(name="choose", description="Let GIR choose from a comma-separated list")
+    async def choose(self, interaction: discord.Interaction, choices: str):
+        items = [item.strip() for item in choices.split(",") if item.strip()]
+        if len(items) < 2:
+            await interaction.response.send_message("Give me at least two choices separated by commas.", ephemeral=True); return
+        await interaction.response.send_message(f"I choose **{random.choice(items)}**.")
+
+    @app_commands.guilds(cfg.guild_id)
+    @app_commands.command(name="membercount", description="Show how many people are in this server")
+    async def membercount(self, interaction: discord.Interaction):
+        await interaction.response.send_message(f"**{interaction.guild.member_count:,}** members are in {interaction.guild.name}.")
+
+    @app_commands.default_permissions(manage_nicknames=True)
+    @app_commands.guilds(cfg.guild_id)
+    @app_commands.command(name="nickname", description="Change or clear a member's nickname")
+    async def nickname(self, interaction: discord.Interaction, member: discord.Member, nickname: str | None = None):
+        await member.edit(nick=nickname, reason=f"Changed by {interaction.user}")
+        await interaction.response.send_message("Nickname updated.", ephemeral=True)
+
+    @app_commands.default_permissions(manage_messages=True)
+    @app_commands.guilds(cfg.guild_id)
+    @app_commands.command(name="embed", description="Post a simple formatted message")
+    async def embed_message(self, interaction: discord.Interaction, channel: discord.TextChannel, title: str, message: str, color: str = "5865F2"):
+        try:
+            embed_color = discord.Color(int(color.lstrip("#"), 16))
+        except ValueError:
+            await interaction.response.send_message("Use a six-character color such as 5865F2.", ephemeral=True); return
+        await channel.send(embed=discord.Embed(title=title[:256], description=message[:4000], color=embed_color))
+        await interaction.response.send_message("Formatted message posted.", ephemeral=True)
+
+    games = app_commands.Group(name="games", description="Free game alerts and current giveaways", guild_ids=[cfg.guild_id])
+
+    @games.command(name="free", description="List free games and giveaways available now")
+    async def games_free(self, interaction: discord.Interaction):
+        await interaction.response.defer(ephemeral=True)
+        settings = self.settings()["freeGames"]
+        try:
+            games = self.filtered_games(await self.fetch_free_games(), settings)[:10]
+        except Exception:
+            await interaction.followup.send("I could not reach the free-game list right now.", ephemeral=True); return
+        if not games:
+            await interaction.followup.send("No matching giveaways are listed right now.", ephemeral=True); return
+        lines = [f"• [{game.get('title', 'Free game')}]({game.get('open_giveaway_url') or game.get('gamerpower_url')}) — {game.get('platforms', 'Unknown platform')}" for game in games]
+        embed = discord.Embed(title="Free games available now", description="\n".join(lines)[:4000], color=discord.Color.green())
+        embed.add_field(name="Source", value="[Giveaway data from GamerPower](https://www.gamerpower.com/)")
+        await interaction.followup.send(embed=embed, ephemeral=True)
+
+    movie = app_commands.Group(name="movie", description="Plan a server movie night", guild_ids=[cfg.guild_id])
+
+    @movie.command(name="suggest", description="Suggest a movie and let members vote")
+    async def movie_suggest(self, interaction: discord.Interaction, title: str, notes: str = ""):
+        settings = self.settings()["movieNight"]
+        channel = interaction.guild.get_channel(int(settings.get("channelID") or 0)) if settings.get("enabled") else None
+        if not channel:
+            await interaction.response.send_message("Movie night is not set up yet.", ephemeral=True); return
+        embed = discord.Embed(title=f"🎬 {title[:240]}", description=notes[:3500] or "Would you watch this?", color=discord.Color.purple())
+        embed.set_footer(text=f"Suggested by {interaction.user.display_name}")
+        post = await channel.send(embed=embed); await post.add_reaction("👍"); await post.add_reaction("👎")
+        await interaction.response.send_message("Your movie was added for voting.", ephemeral=True)
+
+    @movie.command(name="poll", description="Create a movie-night vote from comma-separated titles")
+    @app_commands.default_permissions(manage_events=True)
+    async def movie_poll(self, interaction: discord.Interaction, titles: str, when: str = "Date to be decided"):
+        options = [value.strip() for value in titles.split(",") if value.strip()][:10]
+        if len(options) < 2:
+            await interaction.response.send_message("Add at least two movie titles separated by commas.", ephemeral=True); return
+        settings = self.settings()["movieNight"]; channel = interaction.guild.get_channel(int(settings.get("channelID") or 0)) or interaction.channel
+        numbers = ["1️⃣", "2️⃣", "3️⃣", "4️⃣", "5️⃣", "6️⃣", "7️⃣", "8️⃣", "9️⃣", "🔟"]
+        embed = discord.Embed(title="🎬 Movie night vote", description="\n".join(f"{numbers[i]} {title}" for i, title in enumerate(options)), color=discord.Color.purple())
+        embed.add_field(name="When", value=when[:1024]); role = interaction.guild.get_role(int(settings.get("pingRoleID") or 0))
+        await interaction.response.defer(ephemeral=True); post = await channel.send(content=role.mention if role else None, embed=embed, allowed_mentions=discord.AllowedMentions(roles=True))
+        for emoji in numbers[:len(options)]: await post.add_reaction(emoji)
+        await interaction.followup.send("Movie-night vote posted.", ephemeral=True)
+
+    emoji = app_commands.Group(name="emoji", description="Manage server emojis", guild_ids=[cfg.guild_id], default_permissions=discord.Permissions(manage_emojis=True))
+
+    async def image_from_url(self, url: str) -> bytes:
+        if not url.startswith("https://"):
+            raise ValueError("Use an HTTPS image URL.")
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url, timeout=15) as response:
+                response.raise_for_status(); data = await response.read()
+        if len(data) > 256 * 1024: raise ValueError("Discord emoji images must be smaller than 256 KB.")
+        return data
+
+    @emoji.command(name="add", description="Add an emoji from an image URL")
+    async def emoji_add(self, interaction: discord.Interaction, name: str, image_url: str):
+        await interaction.response.defer(ephemeral=True)
+        try: emoji = await interaction.guild.create_custom_emoji(name=name[:32], image=await self.image_from_url(image_url), reason=f"Added by {interaction.user}")
+        except Exception as error: await interaction.followup.send(f"I could not add that emoji: {error}", ephemeral=True); return
+        await interaction.followup.send(f"Added {emoji}.", ephemeral=True)
+
+    @emoji.command(name="copy", description="Copy a custom emoji into this server")
+    async def emoji_copy(self, interaction: discord.Interaction, emoji: str, new_name: str = ""):
+        match = re.fullmatch(r"<a?:([A-Za-z0-9_]+):(\d+)>", emoji)
+        if not match: await interaction.response.send_message("Paste a custom Discord emoji, such as <:name:123>.", ephemeral=True); return
+        extension = "gif" if emoji.startswith("<a:") else "png"; url = f"https://cdn.discordapp.com/emojis/{match.group(2)}.{extension}"
+        await interaction.response.defer(ephemeral=True)
+        try: created = await interaction.guild.create_custom_emoji(name=(new_name or match.group(1))[:32], image=await self.image_from_url(url), reason=f"Copied by {interaction.user}")
+        except Exception as error: await interaction.followup.send(f"I could not copy that emoji: {error}", ephemeral=True); return
+        await interaction.followup.send(f"Added {created}.", ephemeral=True)
+
+    @emoji.command(name="delete", description="Delete a server emoji by name")
+    async def emoji_delete(self, interaction: discord.Interaction, name: str):
+        emoji = discord.utils.get(interaction.guild.emojis, name=name)
+        if not emoji: await interaction.response.send_message("I could not find that emoji.", ephemeral=True); return
+        await emoji.delete(reason=f"Deleted by {interaction.user}"); await interaction.response.send_message(f"Deleted `{name}`.", ephemeral=True)
+
+    @emoji.command(name="list", description="List this server's custom emojis")
+    async def emoji_list(self, interaction: discord.Interaction):
+        text = " ".join(str(emoji) for emoji in interaction.guild.emojis) or "This server has no custom emojis."
+        await interaction.response.send_message(text[:2000], ephemeral=True)
+
+    @emoji.command(name="stats", description="Show emoji capacity and usage")
+    async def emoji_stats(self, interaction: discord.Interaction):
+        static = sum(not item.animated for item in interaction.guild.emojis); animated = sum(item.animated for item in interaction.guild.emojis)
+        await interaction.response.send_message(f"Static emojis: **{static}**\nAnimated emojis: **{animated}**\nServer emoji limit: **{interaction.guild.emoji_limit}** per type", ephemeral=True)
+
+    @emoji.command(name="export", description="Export server emojis as a ZIP file")
+    async def emoji_export(self, interaction: discord.Interaction):
+        await interaction.response.defer(ephemeral=True); archive = BytesIO()
+        async with aiohttp.ClientSession() as session:
+            with zipfile.ZipFile(archive, "w", zipfile.ZIP_DEFLATED) as bundle:
+                for item in interaction.guild.emojis:
+                    try:
+                        async with session.get(item.url, timeout=15) as response: data = await response.read()
+                        bundle.writestr(f"{item.name}.{('gif' if item.animated else 'png')}", data)
+                    except Exception: pass
+        archive.seek(0); await interaction.followup.send(file=discord.File(archive, filename=f"{interaction.guild.name}-emojis.zip"), ephemeral=True)
+
+    @emoji.command(name="import", description="Import PNG, JPEG, GIF, or WebP images from a ZIP")
+    async def emoji_import(self, interaction: discord.Interaction, file: discord.Attachment):
+        if file.size > 8 * 1024 * 1024: await interaction.response.send_message("Choose a ZIP smaller than 8 MB.", ephemeral=True); return
+        await interaction.response.defer(ephemeral=True); added = 0
+        try:
+            with zipfile.ZipFile(BytesIO(await file.read())) as bundle:
+                safe = [info for info in bundle.infolist() if not info.is_dir() and info.file_size <= 256*1024 and info.filename.lower().endswith((".png", ".jpg", ".jpeg", ".gif", ".webp"))][:50]
+                for info in safe:
+                    name = re.sub(r"[^A-Za-z0-9_]", "_", Path(info.filename).stem)[:32]
+                    if len(name) < 2: continue
+                    try: await interaction.guild.create_custom_emoji(name=name, image=bundle.read(info), reason=f"Imported by {interaction.user}"); added += 1
+                    except discord.HTTPException: pass
+        except (zipfile.BadZipFile, OSError): await interaction.followup.send("That file is not a readable ZIP.", ephemeral=True); return
+        await interaction.followup.send(f"Imported **{added}** emojis.", ephemeral=True)
+
+    @emoji.command(name="role-icon", description="Set a role icon from an image URL")
+    async def emoji_role_icon(self, interaction: discord.Interaction, role: discord.Role, image_url: str):
+        await interaction.response.defer(ephemeral=True)
+        try: await role.edit(display_icon=await self.image_from_url(image_url), reason=f"Changed by {interaction.user}")
+        except Exception as error: await interaction.followup.send(f"I could not set that role icon: {error}", ephemeral=True); return
+        await interaction.followup.send("Role icon updated.", ephemeral=True)
+
+    @emoji.command(name="pfp", description="Make an emoji from a Discord user's profile picture")
+    async def emoji_pfp(self, interaction: discord.Interaction, name: str, discord_id: str):
+        if not discord_id.isdigit(): await interaction.response.send_message("Enter a numeric Discord user ID.", ephemeral=True); return
+        await interaction.response.defer(ephemeral=True)
+        try:
+            user = await self.bot.fetch_user(int(discord_id)); data = await user.display_avatar.with_size(128).read()
+            emoji = await interaction.guild.create_custom_emoji(name=name[:32], image=data, reason=f"Added by {interaction.user}")
+        except Exception as error: await interaction.followup.send(f"I could not create that emoji: {error}", ephemeral=True); return
+        await interaction.followup.send(f"Added {emoji} from {user}.", ephemeral=True)
+
+    @app_commands.guilds(cfg.guild_id)
+    @app_commands.command(name="pfp", description="Get a Discord user's profile picture from their ID")
+    async def pfp(self, interaction: discord.Interaction, discord_id: str):
+        if not discord_id.isdigit(): await interaction.response.send_message("Enter a numeric Discord user ID.", ephemeral=True); return
+        try: user = await self.bot.fetch_user(int(discord_id))
+        except discord.NotFound: await interaction.response.send_message("I could not find that Discord user.", ephemeral=True); return
+        embed = discord.Embed(title=f"{user}'s profile picture", color=discord.Color.blurple()); embed.set_image(url=user.display_avatar.url)
+        await interaction.response.send_message(embed=embed)
+
+    sticker = app_commands.Group(name="sticker", description="Manage server stickers", guild_ids=[cfg.guild_id], default_permissions=discord.Permissions(manage_emojis=True))
+
+    @sticker.command(name="list", description="List this server's stickers")
+    async def sticker_list(self, interaction: discord.Interaction):
+        stickers = await interaction.guild.fetch_stickers(); text = "\n".join(f"• {item.name} — {item.url}" for item in stickers) or "This server has no stickers."
+        await interaction.response.send_message(text[:2000], ephemeral=True)
+
+    @sticker.command(name="add", description="Add a sticker from an image URL")
+    async def sticker_add(self, interaction: discord.Interaction, name: str, image_url: str, emoji: str, description: str = "Server sticker"):
+        await interaction.response.defer(ephemeral=True)
+        try:
+            data = await self.image_from_url(image_url); extension = Path(image_url.split("?", 1)[0]).suffix.lower() or ".png"
+            sticker = await interaction.guild.create_sticker(name=name[:30], description=description[:100], emoji=emoji, file=discord.File(BytesIO(data), filename="sticker" + extension), reason=f"Added by {interaction.user}")
+        except Exception as error: await interaction.followup.send(f"I could not add that sticker: {error}", ephemeral=True); return
+        await interaction.followup.send(f"Added sticker `{sticker.name}`.", ephemeral=True)
+
+    @sticker.command(name="delete", description="Delete a server sticker by name")
+    async def sticker_delete(self, interaction: discord.Interaction, name: str):
+        sticker = discord.utils.get(await interaction.guild.fetch_stickers(), name=name)
+        if not sticker: await interaction.response.send_message("I could not find that sticker.", ephemeral=True); return
+        await sticker.delete(reason=f"Deleted by {interaction.user}"); await interaction.response.send_message(f"Deleted `{name}`.", ephemeral=True)
 
 
 async def setup(bot):

--- a/cogs/community_suite.py
+++ b/cogs/community_suite.py
@@ -13,6 +13,7 @@ import re
 import zipfile
 from io import BytesIO
 import time
+from urllib.parse import quote
 from collections import defaultdict, deque
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -32,6 +33,8 @@ DATA_FILE = Path(os.environ.get(
 ))
 GAME_STATE_FILE = DATA_FILE.with_name("free-games-state.json")
 GAME_API = "https://www.gamerpower.com/api/giveaways"
+EPIC_API = "https://store-site-backend-static.ak.epicgames.com/freeGamesPromotions?locale=en-US&country=US&allowCountries=US"
+CHEAPSHARK_API = "https://www.cheapshark.com/api/1.0/deals?upperPrice=0&onSale=1&pageSize=60&sortBy=Recent"
 
 DEFAULTS = {
     "automod": {
@@ -46,7 +49,7 @@ DEFAULTS = {
     "autorole": {"enabled": False, "roleIDs": []},
     "starboard": {"enabled": False, "channelID": 0, "threshold": 3, "emoji": "⭐"},
     "suggestions": {"enabled": False, "channelID": 0},
-    "freeGames": {"enabled": False, "channelID": 0, "platforms": ["pc", "steam", "epic-games-store", "ps4", "ps5", "xbox-one", "xbox-series-xs"], "types": ["game"], "pingRoleID": 0, "minimumWorth": 0, "hideUnrated": False, "includeExpired": False, "maxPostsPerCheck": 5},
+    "freeGames": {"enabled": False, "channelID": 0, "platforms": ["pc", "steam", "epic-games-store", "ps4", "ps5", "xbox-one", "xbox-series-xs"], "types": ["game"], "sources": ["gamerpower", "epic", "cheapshark"], "checkMinutes": 15, "pingRoleID": 0, "minimumWorth": 0, "hideUnrated": False, "includeExpired": False, "maxPostsPerCheck": 5},
     "movieNight": {"enabled": False, "channelID": 0, "pingRoleID": 0},
     "relay": {"enabled": False, "destinationGuildID": 0, "messages": True, "edits": True,
               "deletes": True, "reactions": True, "channelRoutes": []},
@@ -91,6 +94,7 @@ class CommunitySuite(commands.Cog):
         self.star_posts = {}
         self.afk = {}
         self.relay_queue = asyncio.Queue(maxsize=10000)
+        self.game_provider_health = {}
         self.relay_worker = asyncio.create_task(self._relay_worker())
         self.free_game_check.start()
 
@@ -145,13 +149,87 @@ class CommunitySuite(commands.Cog):
             finally:
                 self.relay_queue.task_done()
 
-    async def fetch_free_games(self):
-        async with aiohttp.ClientSession(headers={"User-Agent": "GIR Discord Bot"}) as session:
-            async with session.get(GAME_API, timeout=20) as response:
+    async def _fetch_json(self, session, name, url):
+        try:
+            async with session.get(url, timeout=aiohttp.ClientTimeout(total=20)) as response:
                 if response.status == 201:
-                    return []
+                    return name, []
                 response.raise_for_status()
-                return await response.json()
+                return name, await response.json(content_type=None)
+        except (aiohttp.ClientError, asyncio.TimeoutError, ValueError) as error:
+            logger.warning("Free-game provider %s failed: %s", name, error)
+            return name, error
+
+    @staticmethod
+    def _epic_games(payload):
+        rows = payload.get("data", {}).get("Catalog", {}).get("searchStore", {}).get("elements", [])
+        games = []
+        for row in rows:
+            promotions = (row.get("promotions") or {}).get("promotionalOffers") or []
+            offers = [offer for block in promotions for offer in block.get("promotionalOffers", [])]
+            free = next((offer for offer in offers if offer.get("discountSetting", {}).get("discountPercentage") == 0), None)
+            if not free:
+                continue
+            images = row.get("keyImages") or []
+            image = next((item.get("url") for item in images if item.get("type") in {"OfferImageWide", "DieselStoreFrontWide"}), None)
+            slug = row.get("productSlug") or row.get("urlSlug") or ""
+            price = row.get("price", {}).get("totalPrice", {}).get("fmtPrice", {}).get("originalPrice") or "Unknown"
+            games.append({"id": f"epic:{row.get('id')}", "title": row.get("title"), "description": row.get("description"),
+                          "platforms": "PC, Epic Games Store", "type": "game", "worth": price,
+                          "end_date": free.get("endDate"), "image": image,
+                          "open_giveaway_url": f"https://store.epicgames.com/p/{slug}" if slug else "https://store.epicgames.com/free-games",
+                          "source": "Epic Games Store", "source_url": "https://store.epicgames.com/free-games"})
+        return games
+
+    @staticmethod
+    def _cheapshark_games(rows):
+        return [{"id": f"cheapshark:{row.get('dealID')}", "title": row.get("title"), "description": "A store deal currently listed at no cost.",
+                 "platforms": "PC", "type": "game", "worth": f"${float(row.get('normalPrice') or 0):.2f}",
+                 "end_date": None, "thumbnail": row.get("thumb"),
+                 "open_giveaway_url": f"https://www.cheapshark.com/redirect?dealID={quote(str(row.get('dealID') or ''), safe='')}",
+                 "source": "CheapShark", "source_url": "https://www.cheapshark.com/"}
+                for row in rows if float(row.get("salePrice") or 1) == 0]
+
+    @staticmethod
+    def _dedupe_games(games):
+        unique = {}
+        for game in games:
+            key = re.sub(r"[^a-z0-9]", "", str(game.get("title", "")).lower())
+            if key and key not in unique:
+                unique[key] = game
+        return list(unique.values())
+
+    @staticmethod
+    def _game_date(value):
+        if not value:
+            return None
+        try:
+            return datetime.fromisoformat(str(value).replace("Z", "+00:00")).astimezone(timezone.utc)
+        except ValueError:
+            try:
+                return datetime.strptime(str(value), "%Y-%m-%d %H:%M:%S").replace(tzinfo=timezone.utc)
+            except ValueError:
+                return None
+
+    async def fetch_free_games(self, settings=None):
+        enabled = set((settings or {}).get("sources") or ["gamerpower", "epic", "cheapshark"])
+        urls = {"gamerpower": GAME_API + "?sort-by=date", "epic": EPIC_API, "cheapshark": CHEAPSHARK_API}
+        async with aiohttp.ClientSession(headers={"User-Agent": "GIR Discord Bot/1.0"}) as session:
+            results = await asyncio.gather(*(self._fetch_json(session, name, url) for name, url in urls.items() if name in enabled))
+        games = []
+        for name, payload in results:
+            if isinstance(payload, Exception):
+                self.game_provider_health[name] = "Unavailable"
+                continue
+            self.game_provider_health[name] = f"OK · {len(payload.get('data', {}).get('Catalog', {}).get('searchStore', {}).get('elements', [])) if name == 'epic' else len(payload)} records"
+            if name == "gamerpower":
+                # Preserve GamerPower's historical IDs so upgrades do not repost every active offer.
+                games.extend({**item, "id": str(item.get("id")), "source": "GamerPower", "source_url": "https://www.gamerpower.com/"} for item in payload)
+            elif name == "epic":
+                games.extend(self._epic_games(payload))
+            elif name == "cheapshark":
+                games.extend(self._cheapshark_games(payload))
+        return self._dedupe_games(games)
 
     def filtered_games(self, games, settings):
         platforms = {str(value).lower() for value in settings.get("platforms", [])}
@@ -166,14 +244,18 @@ class CommunitySuite(commands.Cog):
         def active(game):
             if settings.get("includeExpired") or not game.get("end_date"):
                 return True
-            try:
-                end = datetime.strptime(game["end_date"], "%Y-%m-%d %H:%M:%S").replace(tzinfo=timezone.utc)
-                return end > now
-            except (TypeError, ValueError):
-                return True
+            end = self._game_date(game["end_date"])
+            return end is None or end > now
+
+        aliases = {"epic-games-store": "epic games store", "ps4": "playstation 4", "ps5": "playstation 5",
+                   "xbox-one": "xbox one", "xbox-series-xs": "xbox series x/s", "itchio": "itch.io"}
+
+        def platform_matches(game):
+            offered = {part.strip().lower() for part in str(game.get("platforms", "")).split(",")}
+            return not platforms or any((value == "pc" and "pc" in offered) or aliases.get(value, value) in offered for value in platforms)
 
         return [game for game in games
-                if (not platforms or any(platform in str(game.get("platforms", "")).lower() for platform in platforms))
+                if platform_matches(game)
                 and (not types or str(game.get("type", "")).lower() in types)
                 and worth(game) >= minimum_worth
                 and (not settings.get("hideUnrated") or worth(game) > 0)
@@ -182,13 +264,16 @@ class CommunitySuite(commands.Cog):
     @tasks.loop(minutes=15)
     async def free_game_check(self):
         settings = self.settings()["freeGames"]
+        minutes = min(1440, max(5, int(settings.get("checkMinutes", 15) or 15)))
+        if self.free_game_check.minutes != minutes:
+            self.free_game_check.change_interval(minutes=minutes)
         if not settings.get("enabled"):
             return
         channel = self.bot.get_channel(int(settings.get("channelID") or 0))
         if not channel:
             return
         try:
-            games = self.filtered_games(await self.fetch_free_games(), settings)
+            games = self.filtered_games(await self.fetch_free_games(settings), settings)
             try:
                 seen = set(json.loads(GAME_STATE_FILE.read_text()).get("seen", []))
             except (OSError, ValueError, TypeError):
@@ -208,22 +293,26 @@ class CommunitySuite(commands.Cog):
     async def before_free_game_check(self):
         await self.bot.wait_until_ready()
 
-    async def post_game(self, channel, game, settings):
+    @staticmethod
+    def game_embed(game):
         title = str(game.get("title", "Free game"))[:256]
         description = str(game.get("description", ""))[:2800]
         url = game.get("open_giveaway_url") or game.get("gamerpower_url") or "https://www.gamerpower.com/"
         embed = discord.Embed(title=title, url=url, description=description, color=discord.Color.green())
         embed.add_field(name="Platforms", value=str(game.get("platforms", "Unknown"))[:1024])
         embed.add_field(name="Normal price", value=str(game.get("worth") or "Unknown"))
-        try:
-            end_time = datetime.strptime(str(game.get("end_date")), "%Y-%m-%d %H:%M:%S").replace(tzinfo=timezone.utc)
-            end_label = discord.utils.format_dt(end_time, "R")
-        except (TypeError, ValueError):
-            end_label = "While supplies last"
+        end_time = CommunitySuite._game_date(game.get("end_date"))
+        end_label = discord.utils.format_dt(end_time, "R") if end_time else "While supplies last"
         embed.add_field(name="Ends", value=end_label)
         if game.get("image") or game.get("thumbnail"):
             embed.set_image(url=game.get("image") or game.get("thumbnail"))
-        embed.add_field(name="Source", value="[Giveaway data from GamerPower](https://www.gamerpower.com/)", inline=False)
+        source = str(game.get("source") or "Giveaway source")
+        source_url = str(game.get("source_url") or url)
+        embed.add_field(name="Source", value=f"[{source}]({source_url})", inline=False)
+        return embed
+
+    async def post_game(self, channel, game, settings):
+        embed = self.game_embed(game)
         role_id = int(settings.get("pingRoleID") or 0); role = channel.guild.get_role(role_id)
         mentions = discord.AllowedMentions(roles=[role] if role else False, users=False, everyone=False)
         await channel.send(content=role.mention if role else None, embed=embed, allowed_mentions=mentions)
@@ -456,8 +545,10 @@ class CommunitySuite(commands.Cog):
 
     @app_commands.default_permissions(manage_messages=True)
     @app_commands.guilds(cfg.guild_id)
-    @app_commands.command(name="announce", description="Post a clear announcement in a channel")
-    async def announce(self, interaction: discord.Interaction, channel: discord.TextChannel, title: str, message: str, color: str = "5865F2"):
+    @app_commands.command(name="announce", description="Create and post a custom embed in a channel")
+    async def announce(self, interaction: discord.Interaction, channel: discord.TextChannel, title: str, message: str,
+                       color: str = "5865F2", image_url: str | None = None,
+                       thumbnail_url: str | None = None, footer: str | None = None):
         color_value = color.lstrip("#")
         try:
             if len(color_value) != 6:
@@ -465,9 +556,17 @@ class CommunitySuite(commands.Cog):
             embed_color = discord.Color(int(color_value, 16))
         except ValueError:
             await interaction.response.send_message("Use a six-character color such as 5865F2.", ephemeral=True); return
+        for label, value in (("image", image_url), ("thumbnail", thumbnail_url)):
+            if value and not value.startswith("https://"):
+                await interaction.response.send_message(f"The {label} must use an HTTPS link.", ephemeral=True); return
         embed = discord.Embed(title=title[:256], description=message[:4000], color=embed_color, timestamp=datetime.now(timezone.utc))
-        embed.set_footer(text=f"Posted by {interaction.user.display_name}")
-        await channel.send(embed=embed); await interaction.response.send_message("Announcement posted.", ephemeral=True)
+        if image_url:
+            embed.set_image(url=image_url)
+        if thumbnail_url:
+            embed.set_thumbnail(url=thumbnail_url)
+        embed.set_footer(text=(footer or f"Posted by {interaction.user.display_name}")[:2048])
+        await channel.send(embed=embed, allowed_mentions=discord.AllowedMentions.none())
+        await interaction.response.send_message("Embed posted.", ephemeral=True)
 
     @app_commands.default_permissions(manage_channels=True)
     @app_commands.guilds(cfg.guild_id)
@@ -525,14 +624,14 @@ class CommunitySuite(commands.Cog):
         await interaction.response.defer(ephemeral=True)
         settings = self.settings()["freeGames"]
         try:
-            games = self.filtered_games(await self.fetch_free_games(), settings)[:10]
+            games = self.filtered_games(await self.fetch_free_games(settings), settings)[:10]
         except Exception:
             await interaction.followup.send("I could not reach the free-game list right now.", ephemeral=True); return
         if not games:
             await interaction.followup.send("No matching giveaways are listed right now.", ephemeral=True); return
         lines = [f"• [{game.get('title', 'Free game')}]({game.get('open_giveaway_url') or game.get('gamerpower_url')}) — {game.get('platforms', 'Unknown platform')}" for game in games]
         embed = discord.Embed(title="Free games available now", description="\n".join(lines)[:4000], color=discord.Color.green())
-        embed.add_field(name="Source", value="[Giveaway data from GamerPower](https://www.gamerpower.com/)")
+        embed.add_field(name="Sources", value=", ".join(sorted({str(game.get("source", "Unknown")) for game in games})))
         await interaction.followup.send(embed=embed, ephemeral=True)
 
     @games.command(name="status", description="Show how free-game alerts are configured")
@@ -545,7 +644,10 @@ class CommunitySuite(commands.Cog):
         embed.add_field(name="Platforms", value=", ".join(settings.get("platforms", [])) or "All", inline=False)
         embed.add_field(name="Offer types", value=", ".join(settings.get("types", [])) or "All")
         embed.add_field(name="Minimum normal price", value=f"${float(settings.get('minimumWorth', 0) or 0):.2f}")
-        embed.set_footer(text="Giveaway data provided by GamerPower")
+        embed.add_field(name="Check schedule", value=f"Every {int(settings.get('checkMinutes', 15))} minutes")
+        health = "\n".join(f"**{name.title()}**: {state}" for name, state in sorted(self.game_provider_health.items()))
+        if health:
+            embed.add_field(name="Source health", value=health[:1024], inline=False)
         await interaction.response.send_message(embed=embed, ephemeral=True)
 
     movie = app_commands.Group(name="movie", description="Plan a server movie night", guild_ids=[cfg.guild_id])

--- a/cogs/community_suite.py
+++ b/cogs/community_suite.py
@@ -11,6 +11,7 @@ import os
 import random
 import re
 import zipfile
+import xml.etree.ElementTree as ET
 from io import BytesIO
 import time
 from urllib.parse import quote, urlparse

--- a/cogs/community_suite.py
+++ b/cogs/community_suite.py
@@ -49,6 +49,10 @@ DEFAULTS = {
         "scamDetection": True, "scamTimeoutHours": 168,
         "monitorAllChannels": True, "monitoredChannelIDs": [], "ignoredChannelIDs": [], "ignoredRoleIDs": [],
     },
+    "reports": {"pingModeratorRole": True, "pingAdministratorRole": False, "pingRoleIDs": [],
+                "pingUserIDs": [], "allowEveryone": True, "allowedRoleIDs": [], "allowedUserIDs": [],
+                "ignoredUserIDs": [], "ignoredMessageIDs": [], "ignoredChannelIDs": [],
+                "ignoredThreadIDs": [], "joinThreadsWhenMentioned": True, "notifyOnIgnoredPing": False},
     "welcome": {"enabled": False, "channelID": 0, "message": "Welcome {mention} to {server}!", "goodbyeEnabled": False, "goodbyeMessage": "{name} left the server."},
     "autorole": {"enabled": False, "roleIDs": []},
     "starboard": {"enabled": False, "channelID": 0, "threshold": 3, "emoji": "⭐"},
@@ -448,6 +452,42 @@ class CommunitySuite(commands.Cog):
         ignored = set(settings.get("ignoredRoleIDs", []))
         return member.guild_permissions.manage_messages or any(role.id in ignored for role in member.roles)
 
+    @staticmethod
+    def _ids(values):
+        return {int(value) for value in values if str(value).isdigit()}
+
+    def _ignored(self, message: discord.Message) -> bool:
+        rules = self.settings().get("reports", {})
+        channel_ids = {message.channel.id, int(getattr(message.channel, "parent_id", 0) or 0)}
+        return (message.author.id in self._ids(rules.get("ignoredUserIDs", []))
+                or message.id in self._ids(rules.get("ignoredMessageIDs", []))
+                or bool(channel_ids & self._ids(rules.get("ignoredChannelIDs", [])))
+                or message.channel.id in self._ids(rules.get("ignoredThreadIDs", [])))
+
+    def _report_access(self, member: discord.Member) -> bool:
+        rules = self.settings().get("reports", {})
+        return (rules.get("allowEveryone", True) or member.guild_permissions.manage_messages
+                or member.id in self._ids(rules.get("allowedUserIDs", []))
+                or bool({role.id for role in member.roles} & self._ids(rules.get("allowedRoleIDs", []))))
+
+    def _report_mentions(self, guild: discord.Guild):
+        rules = self.settings().get("reports", {})
+        role_ids = self._ids(rules.get("pingRoleIDs", []))
+        if rules.get("pingModeratorRole", True):
+            role_ids.add(int(getattr(cfg.roles, "moderator", 0) or 0))
+        if rules.get("pingAdministratorRole", False):
+            role_ids.add(int(getattr(cfg.roles, "administrator", 0) or 0))
+        roles = [guild.get_role(value) for value in role_ids]
+        roles = [role for role in roles if role]
+        users = [guild.get_member(value) for value in self._ids(rules.get("pingUserIDs", []))]
+        users = [user for user in users if user]
+        content = " ".join([role.mention for role in roles] + [user.mention for user in users])
+        return content or None, discord.AllowedMentions(roles=roles, users=users, everyone=False)
+
+    def _report_channel(self, guild: discord.Guild):
+        configured = int(self.settings().get("automod", {}).get("reportChannelID", 0) or 0)
+        return (guild.get_channel(configured) if configured else None) or discord.utils.get(guild.text_channels, name="reports") or guild.get_channel(int(getattr(cfg.channels, "reports", 0) or 0))
+
     @commands.Cog.listener()
     async def on_member_join(self, member: discord.Member):
         settings = self.settings()
@@ -483,6 +523,17 @@ class CommunitySuite(commands.Cog):
             "jumpURL": message.jump_url, "attachments": [item.url for item in message.attachments]})
         settings = self.settings()
         lowered = message.content.lower().strip()
+
+        if (isinstance(message.channel, discord.Thread) and self.bot.user in message.mentions
+                and settings.get("reports", {}).get("joinThreadsWhenMentioned", True)):
+            try:
+                await message.channel.join()
+                if settings.get("reports", {}).get("notifyOnIgnoredPing", False):
+                    await message.reply("I joined this thread and can monitor it now.", mention_author=False)
+            except discord.HTTPException:
+                logger.warning("GIR could not join mentioned thread %s", message.channel.id)
+        if self._ignored(message):
+            return
 
         attachment_text = " ".join(f"{item.filename} {getattr(item, 'description', '') or ''}" for item in message.attachments)
         scam_reason = detect_scam(f"{message.content} {attachment_text}")
@@ -585,10 +636,7 @@ class CommunitySuite(commands.Cog):
                 action = f"Timed out for {hours} hours"
             except discord.HTTPException:
                 action = "Message removed; timeout could not be applied"
-        report_id = int(settings.get("reportChannelID") or 0)
-        channel = message.guild.get_channel(report_id) if report_id else None
-        channel = channel or discord.utils.get(message.guild.text_channels, name="reports")
-        channel = channel or message.guild.get_channel(int(getattr(cfg.channels, "reports", 0) or 0))
+        channel = self._report_channel(message.guild)
         if not channel:
             return
         embed = discord.Embed(title="🚨 Automatic moderation alert", color=discord.Color.red(), timestamp=datetime.now(timezone.utc))
@@ -601,7 +649,8 @@ class CommunitySuite(commands.Cog):
         view = discord.ui.View(timeout=None)
         view.add_item(discord.ui.Button(label="Ban", style=discord.ButtonStyle.danger, custom_id=f"gir:report:ban:{message.author.id}"))
         view.add_item(discord.ui.Button(label="Dismiss", style=discord.ButtonStyle.secondary, custom_id=f"gir:report:dismiss:{message.author.id}"))
-        await channel.send(embed=embed, view=view)
+        content, mentions = self._report_mentions(message.guild)
+        await channel.send(content=content, embed=embed, view=view, allowed_mentions=mentions)
 
     @commands.Cog.listener()
     async def on_interaction(self, interaction: discord.Interaction):
@@ -747,13 +796,34 @@ class CommunitySuite(commands.Cog):
     @app_commands.guilds(cfg.guild_id)
     @app_commands.command(name="report", description="Privately report a member to the moderation team")
     async def report(self, interaction: discord.Interaction, member: discord.Member, reason: str):
-        channel = interaction.guild.get_channel(int(getattr(cfg.channels, "reports", 0)))
+        channel = self._report_channel(interaction.guild)
         if not channel:
             await interaction.response.send_message("The reports channel is not set up yet.", ephemeral=True); return
+        if not self._report_access(interaction.user):
+            await interaction.response.send_message("You are not in a role allowed to submit reports.", ephemeral=True); return
         embed = discord.Embed(title="Member report", description=reason[:4000], color=discord.Color.orange(), timestamp=datetime.now(timezone.utc))
         embed.add_field(name="Reported member", value=f"{member.mention}\n`{member.id}`")
         embed.add_field(name="Reported by", value=f"{interaction.user.mention}\n`{interaction.user.id}`")
-        await channel.send(embed=embed); await interaction.response.send_message("Your report was sent privately to the moderators.", ephemeral=True)
+        content, mentions = self._report_mentions(interaction.guild)
+        await channel.send(content=content, embed=embed, allowed_mentions=mentions); await interaction.response.send_message("Your report was sent privately to the moderators.", ephemeral=True)
+
+    @app_commands.guilds(cfg.guild_id)
+    @app_commands.context_menu(name="Report message")
+    async def report_message(self, interaction: discord.Interaction, message: discord.Message):
+        if not self._report_access(interaction.user):
+            await interaction.response.send_message("You are not in a role allowed to report messages.", ephemeral=True); return
+        if self._ignored(message):
+            await interaction.response.send_message("GIR is configured to ignore that message, person, channel, or thread.", ephemeral=True); return
+        channel = self._report_channel(interaction.guild)
+        if not channel:
+            await interaction.response.send_message("The reports channel is not set up yet.", ephemeral=True); return
+        embed = discord.Embed(title="Message reported", description=(message.content or "No message text")[:3500], color=discord.Color.orange(), timestamp=datetime.now(timezone.utc))
+        embed.add_field(name="Message author", value=f"{message.author.mention}\n`{message.author.id}`", inline=True)
+        embed.add_field(name="Reported by", value=f"{interaction.user.mention}\n`{interaction.user.id}`", inline=True)
+        embed.add_field(name="Location", value=f"{message.channel.mention}\n[Open message]({message.jump_url})", inline=False)
+        content, mentions = self._report_mentions(interaction.guild)
+        await channel.send(content=content, embed=embed, allowed_mentions=mentions)
+        await interaction.response.send_message("That message was sent privately to the moderation team.", ephemeral=True)
 
     @app_commands.guilds(cfg.guild_id)
     @app_commands.command(name="afk", description="Let people know you are away")

--- a/cogs/community_suite.py
+++ b/cogs/community_suite.py
@@ -111,7 +111,6 @@ class CommunitySuite(commands.Cog):
         self.free_game_check.cancel()
         self.free_game_request_check.cancel()
         self.relay_worker.cancel()
-        self.bot.tree.remove_command("Report message", guild=discord.Object(id=cfg.guild_id), type=discord.AppCommandType.message)
 
     def settings(self):
         return load_settings()
@@ -1083,5 +1082,3 @@ class CommunitySuite(commands.Cog):
 async def setup(bot):
     cog = CommunitySuite(bot)
     await bot.add_cog(cog)
-    bot.tree.add_command(app_commands.ContextMenu(name="Report message", callback=cog.report_message),
-                         guild=discord.Object(id=cfg.guild_id))

--- a/cogs/community_suite.py
+++ b/cogs/community_suite.py
@@ -292,9 +292,19 @@ class CommunitySuite(commands.Cog):
         minutes = min(1440, max(5, int(settings.get("checkMinutes", 15) or 15)))
         channel = self.bot.get_channel(int(settings.get("channelID") or 0))
         if not channel:
-            preferred = {"free-games", "freebies", "game-deals", "giveaways"}
+            preferred = ("free-games", "freebies", "game-deals", "giveaways")
             guild = self.bot.get_guild(cfg.guild_id)
-            channel = next((item for item in getattr(guild, "text_channels", []) if item.name.lower() in preferred), None)
+            by_name = {item.name.lower(): item for item in getattr(guild, "text_channels", [])}
+            channel = next((by_name[name] for name in preferred if name in by_name), None)
+            if channel:
+                try:
+                    saved = json.loads(DATA_FILE.read_text())
+                    saved.setdefault("freeGames", {})["channelID"] = channel.id
+                    temporary = DATA_FILE.with_suffix(".tmp")
+                    temporary.write_text(json.dumps(saved, indent=2, sort_keys=True) + "\n")
+                    temporary.replace(DATA_FILE)
+                except (OSError, ValueError, TypeError):
+                    logger.exception("Could not persist the recovered free-game channel")
         if not channel:
             logger.warning("Free-game alerts are enabled but no valid alert channel is available")
             return self._save_game_status("failed", message="No valid free-game channel is available")

--- a/cogs/community_suite.py
+++ b/cogs/community_suite.py
@@ -48,8 +48,14 @@ DEFAULTS = {
     "suggestions": {"enabled": False, "channelID": 0},
     "freeGames": {"enabled": False, "channelID": 0, "platforms": ["pc", "steam", "epic-games-store", "ps4", "ps5", "xbox-one", "xbox-series-xs"], "types": ["game"], "pingRoleID": 0},
     "movieNight": {"enabled": False, "channelID": 0, "pingRoleID": 0},
+    "relay": {"enabled": False, "destinationGuildID": 0, "messages": True, "edits": True,
+              "deletes": True, "reactions": True, "channelRoutes": []},
+    "appleEvents": {"enabled": False, "channelID": 0, "roleID": 0},
     "customCommands": [], "autoResponses": [], "reactionRoles": [], "disabledCommands": [],
 }
+
+_SETTINGS_CACHE = None
+_SETTINGS_MTIME = None
 
 
 def _merge(base, incoming):
@@ -60,10 +66,17 @@ def _merge(base, incoming):
 
 
 def load_settings():
+    global _SETTINGS_CACHE, _SETTINGS_MTIME
     try:
-        return _merge(DEFAULTS, json.loads(DATA_FILE.read_text()))
+        modified = DATA_FILE.stat().st_mtime_ns
+        if _SETTINGS_CACHE is None or modified != _SETTINGS_MTIME:
+            _SETTINGS_CACHE = _merge(DEFAULTS, json.loads(DATA_FILE.read_text()))
+            _SETTINGS_MTIME = modified
+        return _SETTINGS_CACHE
     except (OSError, ValueError, TypeError):
-        return _merge(DEFAULTS, {})
+        if _SETTINGS_CACHE is None:
+            _SETTINGS_CACHE = _merge(DEFAULTS, {})
+        return _SETTINGS_CACHE
 
 
 def render(template: str, member: discord.Member) -> str:
@@ -77,13 +90,60 @@ class CommunitySuite(commands.Cog):
         self.images = defaultdict(lambda: deque(maxlen=30))
         self.star_posts = {}
         self.afk = {}
+        self.relay_queue = asyncio.Queue(maxsize=10000)
+        self.relay_worker = asyncio.create_task(self._relay_worker())
         self.free_game_check.start()
 
     def cog_unload(self):
         self.free_game_check.cancel()
+        self.relay_worker.cancel()
 
     def settings(self):
         return load_settings()
+
+    def _queue_relay(self, event: str, channel_id: int, payload: dict):
+        relay = self.settings().get("relay", {})
+        event_flag = {"message": "messages", "edit": "edits", "delete": "deletes", "reaction": "reactions"}[event]
+        if not relay.get("enabled") or not relay.get(event_flag):
+            return
+        route = next((item for item in relay.get("channelRoutes", [])
+                      if int(item.get("sourceChannelID", 0)) == channel_id), None)
+        if not route:
+            return
+        payload.update({"event": event, "destinationChannelID": int(route.get("destinationChannelID", 0))})
+        try:
+            self.relay_queue.put_nowait(payload)
+        except asyncio.QueueFull:
+            logger.error("Audit relay queue is full; newest event was dropped")
+
+    async def _relay_worker(self):
+        while True:
+            item = await self.relay_queue.get()
+            try:
+                destination = self.bot.get_channel(item["destinationChannelID"])
+                if not isinstance(destination, discord.TextChannel):
+                    continue
+                colors = {"message": discord.Color.blurple(), "edit": discord.Color.orange(),
+                          "delete": discord.Color.red(), "reaction": discord.Color.green()}
+                titles = {"message": "Message", "edit": "Message edited", "delete": "Message deleted", "reaction": "Reaction"}
+                embed = discord.Embed(title=titles[item["event"]], description=str(item.get("content") or "No text")[:3500],
+                                      color=colors[item["event"]], timestamp=datetime.now(timezone.utc))
+                embed.add_field(name="Member", value=f"{item.get('author', 'Unknown')} · `{item.get('authorID', 'Unknown')}`", inline=False)
+                embed.add_field(name="Source", value=f"#{item.get('channel', 'unknown')} · `{item.get('channelID')}`", inline=True)
+                if item.get("detail"):
+                    embed.add_field(name="Details", value=str(item["detail"])[:1024], inline=True)
+                if item.get("jumpURL"):
+                    embed.add_field(name="Original", value=f"[Open message]({item['jumpURL']})", inline=False)
+                attachments = item.get("attachments", [])
+                if attachments:
+                    embed.add_field(name="Attachments", value="\n".join(attachments)[:1024], inline=False)
+                await destination.send(embed=embed, allowed_mentions=discord.AllowedMentions.none())
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("Could not relay Discord audit event")
+            finally:
+                self.relay_queue.task_done()
 
     async def fetch_free_games(self):
         async with aiohttp.ClientSession(headers={"User-Agent": "GIR Discord Bot"}) as session:
@@ -175,6 +235,9 @@ class CommunitySuite(commands.Cog):
     async def on_message(self, message: discord.Message):
         if not message.guild or message.author.bot or message.guild.id != cfg.guild_id:
             return
+        self._queue_relay("message", message.channel.id, {"author": str(message.author), "authorID": message.author.id,
+            "channel": message.channel.name, "channelID": message.channel.id, "content": message.content,
+            "jumpURL": message.jump_url, "attachments": [item.url for item in message.attachments]})
         settings = self.settings()
         lowered = message.content.lower().strip()
 
@@ -277,6 +340,11 @@ class CommunitySuite(commands.Cog):
     async def on_raw_reaction_add(self, payload: discord.RawReactionActionEvent):
         if payload.guild_id != cfg.guild_id or payload.member is None or payload.member.bot:
             return
+        channel = self.bot.get_channel(payload.channel_id)
+        self._queue_relay("reaction", payload.channel_id, {"author": str(payload.member), "authorID": payload.user_id,
+            "channel": getattr(channel, "name", "unknown"), "channelID": payload.channel_id,
+            "content": str(payload.emoji), "detail": "Reaction added",
+            "jumpURL": f"https://discord.com/channels/{payload.guild_id}/{payload.channel_id}/{payload.message_id}"})
         settings = self.settings()
         for item in settings.get("reactionRoles", []):
             if item.get("enabled", True) and int(item.get("messageID", 0)) == payload.message_id and str(item.get("emoji")) == str(payload.emoji):
@@ -315,12 +383,36 @@ class CommunitySuite(commands.Cog):
     async def on_raw_reaction_remove(self, payload: discord.RawReactionActionEvent):
         if payload.guild_id != cfg.guild_id:
             return
+        guild = self.bot.get_guild(payload.guild_id); member = guild.get_member(payload.user_id) if guild else None
+        channel = self.bot.get_channel(payload.channel_id)
+        if member and not member.bot:
+            self._queue_relay("reaction", payload.channel_id, {"author": str(member), "authorID": payload.user_id,
+                "channel": getattr(channel, "name", "unknown"), "channelID": payload.channel_id,
+                "content": str(payload.emoji), "detail": "Reaction removed",
+                "jumpURL": f"https://discord.com/channels/{payload.guild_id}/{payload.channel_id}/{payload.message_id}"})
         for item in self.settings().get("reactionRoles", []):
             if item.get("enabled", True) and int(item.get("messageID", 0)) == payload.message_id and str(item.get("emoji")) == str(payload.emoji):
                 guild = self.bot.get_guild(payload.guild_id); member = guild.get_member(payload.user_id) if guild else None
                 role = guild.get_role(int(item.get("roleID", 0))) if guild else None
                 if member and role:
                     await member.remove_roles(role, reason="GIR reaction role removed")
+
+    @commands.Cog.listener()
+    async def on_message_edit(self, before: discord.Message, after: discord.Message):
+        if not before.guild or before.guild.id != cfg.guild_id or before.author.bot or before.content == after.content:
+            return
+        self._queue_relay("edit", before.channel.id, {"author": str(before.author), "authorID": before.author.id,
+            "channel": before.channel.name, "channelID": before.channel.id,
+            "content": f"Before:\n{before.content[:1600]}\n\nAfter:\n{after.content[:1600]}", "jumpURL": after.jump_url})
+
+    @commands.Cog.listener()
+    async def on_raw_message_delete(self, payload: discord.RawMessageDeleteEvent):
+        message = payload.cached_message
+        if payload.guild_id != cfg.guild_id or not message or message.author.bot:
+            return
+        self._queue_relay("delete", payload.channel_id, {"author": str(message.author), "authorID": message.author.id,
+            "channel": message.channel.name, "channelID": payload.channel_id, "content": message.content,
+            "attachments": [item.url for item in message.attachments]})
 
     @app_commands.guilds(cfg.guild_id)
     @app_commands.command(name="suggest", description="Send an idea to the server suggestion board")

--- a/cogs/community_suite.py
+++ b/cogs/community_suite.py
@@ -483,17 +483,25 @@ class CommunitySuite(commands.Cog):
                 break
         for item in settings.get("autoResponses", []):
             trigger = str(item.get("trigger", "")).lower().strip()
+            match_mode = str(item.get("matchMode", "contains"))
+            matched = lowered == trigger if match_mode == "exact" else bool(re.search(rf"(?<!\w){re.escape(trigger)}(?!\w)", lowered)) if match_mode == "word" else trigger in lowered
             allowed_channels = {int(value) for value in item.get("channelIDs", []) if str(value).isdigit()}
             message_channels = {message.channel.id, int(getattr(message.channel, "parent_id", 0) or 0)}
-            if (item.get("enabled", True) and trigger and trigger in lowered
+            if (item.get("enabled", True) and trigger and matched
                     and (not allowed_channels or allowed_channels & message_channels)):
                 emoji_text = str(item.get("emojiText", ""))[:100]
                 content = " ".join(value for value in (emoji_text, str(item.get("response", ""))[:1900]) if value).strip()
                 sticker = message.guild.get_sticker(int(item.get("stickerID", 0) or 0))
-                send_options = {"reference": message, "mention_author": False}
-                if sticker:
-                    send_options["stickers"] = [sticker]
-                await message.channel.send(content or None, **send_options)
+                for reaction in item.get("reactionEmojis", [])[:10]:
+                    try:
+                        await message.add_reaction(str(reaction))
+                    except discord.HTTPException:
+                        logger.warning("Could not add configured automatic reaction %s", reaction)
+                if content or sticker:
+                    send_options = {"reference": message, "mention_author": False}
+                    if sticker:
+                        send_options["stickers"] = [sticker]
+                    await message.channel.send(content or None, **send_options)
                 break
 
         auto = settings["automod"]

--- a/cogs/community_suite.py
+++ b/cogs/community_suite.py
@@ -570,6 +570,36 @@ class CommunitySuite(commands.Cog):
         if not sticker: await interaction.response.send_message("I could not find that sticker.", ephemeral=True); return
         await sticker.delete(reason=f"Deleted by {interaction.user}"); await interaction.response.send_message(f"Deleted `{name}`.", ephemeral=True)
 
+    @sticker.command(name="export", description="Export server stickers as a ZIP file")
+    async def sticker_export(self, interaction: discord.Interaction):
+        await interaction.response.defer(ephemeral=True); archive = BytesIO(); stickers = await interaction.guild.fetch_stickers()
+        async with aiohttp.ClientSession() as session:
+            with zipfile.ZipFile(archive, "w", zipfile.ZIP_DEFLATED) as bundle:
+                for item in stickers:
+                    try:
+                        async with session.get(item.url, timeout=15) as response: data = await response.read()
+                        extension = ".png" if item.format in {discord.StickerFormatType.png, discord.StickerFormatType.apng} else ".json"
+                        bundle.writestr(item.name + extension, data)
+                    except Exception: pass
+        archive.seek(0); await interaction.followup.send(file=discord.File(archive, filename=f"{interaction.guild.name}-stickers.zip"), ephemeral=True)
+
+    @sticker.command(name="import", description="Import PNG or APNG stickers from a ZIP")
+    async def sticker_import(self, interaction: discord.Interaction, file: discord.Attachment):
+        if file.size > 8 * 1024 * 1024: await interaction.response.send_message("Choose a ZIP smaller than 8 MB.", ephemeral=True); return
+        await interaction.response.defer(ephemeral=True); added = 0
+        try:
+            with zipfile.ZipFile(BytesIO(await file.read())) as bundle:
+                safe = [info for info in bundle.infolist() if not info.is_dir() and info.file_size <= 512*1024 and info.filename.lower().endswith((".png", ".apng"))][:15]
+                for info in safe:
+                    name = re.sub(r"[^A-Za-z0-9_ ]", "", Path(info.filename).stem)[:30]
+                    if len(name) < 2: continue
+                    try:
+                        upload = discord.File(BytesIO(bundle.read(info)), filename=Path(info.filename).name)
+                        await interaction.guild.create_sticker(name=name, description="Imported by GIR", emoji="⭐", file=upload, reason=f"Imported by {interaction.user}"); added += 1
+                    except discord.HTTPException: pass
+        except (zipfile.BadZipFile, OSError): await interaction.followup.send("That file is not a readable ZIP.", ephemeral=True); return
+        await interaction.followup.send(f"Imported **{added}** stickers.", ephemeral=True)
+
 
 async def setup(bot):
     await bot.add_cog(CommunitySuite(bot))

--- a/cogs/community_suite.py
+++ b/cogs/community_suite.py
@@ -25,7 +25,7 @@ from discord.ext import commands, tasks
 
 from utils import cfg, logger
 from utils.framework.permissions import gatekeeper
-from community_rules import caps_percent, has_invite, is_image_attachment, recent_count
+from community_rules import caps_percent, detect_scam, has_invite, is_image_attachment, recent_count
 
 
 DATA_FILE = Path(os.environ.get(
@@ -46,6 +46,7 @@ DEFAULTS = {
         "imageWindowSeconds": 20, "fastSpam": True, "messageThreshold": 7,
         "messageWindowSeconds": 8, "capsSpam": True, "capsPercent": 80,
         "mentionSpam": True, "mentionThreshold": 6, "inviteLinks": False,
+        "scamDetection": True, "scamTimeoutHours": 168,
         "monitorAllChannels": True, "monitoredChannelIDs": [], "ignoredChannelIDs": [], "ignoredRoleIDs": [],
     },
     "welcome": {"enabled": False, "channelID": 0, "message": "Welcome {mention} to {server}!", "goodbyeEnabled": False, "goodbyeMessage": "{name} left the server."},
@@ -482,6 +483,14 @@ class CommunitySuite(commands.Cog):
             "jumpURL": message.jump_url, "attachments": [item.url for item in message.attachments]})
         settings = self.settings()
         lowered = message.content.lower().strip()
+
+        attachment_text = " ".join(f"{item.filename} {getattr(item, 'description', '') or ''}" for item in message.attachments)
+        scam_reason = detect_scam(f"{message.content} {attachment_text}")
+        if settings["automod"].get("scamDetection", True) and scam_reason and not gatekeeper.has(message.guild, message.author, 1):
+            scam_rule = dict(settings["automod"])
+            scam_rule.update({"deleteMessage": True, "timeoutHours": int(scam_rule.get("scamTimeoutHours", 168))})
+            await self._moderate(message, scam_rule, scam_reason)
+            return
 
         # Prevent image dumps from accounts that have not reached Member+.
         # This focused safety rule stays active when general AutoMod is off.

--- a/cogs/community_suite.py
+++ b/cogs/community_suite.py
@@ -337,8 +337,15 @@ class CommunitySuite(commands.Cog):
     @app_commands.default_permissions(manage_messages=True)
     @app_commands.guilds(cfg.guild_id)
     @app_commands.command(name="announce", description="Post a clear announcement in a channel")
-    async def announce(self, interaction: discord.Interaction, channel: discord.TextChannel, title: str, message: str):
-        embed = discord.Embed(title=title[:256], description=message[:4000], color=discord.Color.blurple(), timestamp=datetime.now(timezone.utc))
+    async def announce(self, interaction: discord.Interaction, channel: discord.TextChannel, title: str, message: str, color: str = "5865F2"):
+        color_value = color.lstrip("#")
+        try:
+            if len(color_value) != 6:
+                raise ValueError
+            embed_color = discord.Color(int(color_value, 16))
+        except ValueError:
+            await interaction.response.send_message("Use a six-character color such as 5865F2.", ephemeral=True); return
+        embed = discord.Embed(title=title[:256], description=message[:4000], color=embed_color, timestamp=datetime.now(timezone.utc))
         embed.set_footer(text=f"Posted by {interaction.user.display_name}")
         await channel.send(embed=embed); await interaction.response.send_message("Announcement posted.", ephemeral=True)
 
@@ -384,28 +391,12 @@ class CommunitySuite(commands.Cog):
             await interaction.response.send_message("Give me at least two choices separated by commas.", ephemeral=True); return
         await interaction.response.send_message(f"I choose **{random.choice(items)}**.")
 
-    @app_commands.guilds(cfg.guild_id)
-    @app_commands.command(name="membercount", description="Show how many people are in this server")
-    async def membercount(self, interaction: discord.Interaction):
-        await interaction.response.send_message(f"**{interaction.guild.member_count:,}** members are in {interaction.guild.name}.")
-
     @app_commands.default_permissions(manage_nicknames=True)
     @app_commands.guilds(cfg.guild_id)
     @app_commands.command(name="nickname", description="Change or clear a member's nickname")
     async def nickname(self, interaction: discord.Interaction, member: discord.Member, nickname: str | None = None):
         await member.edit(nick=nickname, reason=f"Changed by {interaction.user}")
         await interaction.response.send_message("Nickname updated.", ephemeral=True)
-
-    @app_commands.default_permissions(manage_messages=True)
-    @app_commands.guilds(cfg.guild_id)
-    @app_commands.command(name="embed", description="Post a simple formatted message")
-    async def embed_message(self, interaction: discord.Interaction, channel: discord.TextChannel, title: str, message: str, color: str = "5865F2"):
-        try:
-            embed_color = discord.Color(int(color.lstrip("#"), 16))
-        except ValueError:
-            await interaction.response.send_message("Use a six-character color such as 5865F2.", ephemeral=True); return
-        await channel.send(embed=discord.Embed(title=title[:256], description=message[:4000], color=embed_color))
-        await interaction.response.send_message("Formatted message posted.", ephemeral=True)
 
     games = app_commands.Group(name="games", description="Free game alerts and current giveaways", guild_ids=[cfg.guild_id])
 
@@ -538,15 +529,6 @@ class CommunitySuite(commands.Cog):
             emoji = await interaction.guild.create_custom_emoji(name=name[:32], image=data, reason=f"Added by {interaction.user}")
         except Exception as error: await interaction.followup.send(f"I could not create that emoji: {error}", ephemeral=True); return
         await interaction.followup.send(f"Added {emoji} from {user}.", ephemeral=True)
-
-    @app_commands.guilds(cfg.guild_id)
-    @app_commands.command(name="pfp", description="Get a Discord user's profile picture from their ID")
-    async def pfp(self, interaction: discord.Interaction, discord_id: str):
-        if not discord_id.isdigit(): await interaction.response.send_message("Enter a numeric Discord user ID.", ephemeral=True); return
-        try: user = await self.bot.fetch_user(int(discord_id))
-        except discord.NotFound: await interaction.response.send_message("I could not find that Discord user.", ephemeral=True); return
-        embed = discord.Embed(title=f"{user}'s profile picture", color=discord.Color.blurple()); embed.set_image(url=user.display_avatar.url)
-        await interaction.response.send_message(embed=embed)
 
     sticker = app_commands.Group(name="sticker", description="Manage server stickers", guild_ids=[cfg.guild_id], default_permissions=discord.Permissions(manage_emojis=True))
 

--- a/cogs/community_suite.py
+++ b/cogs/community_suite.py
@@ -46,7 +46,7 @@ DEFAULTS = {
     "autorole": {"enabled": False, "roleIDs": []},
     "starboard": {"enabled": False, "channelID": 0, "threshold": 3, "emoji": "⭐"},
     "suggestions": {"enabled": False, "channelID": 0},
-    "freeGames": {"enabled": False, "channelID": 0, "platforms": ["pc", "steam", "epic-games-store", "ps4", "ps5", "xbox-one", "xbox-series-xs"], "types": ["game"], "pingRoleID": 0},
+    "freeGames": {"enabled": False, "channelID": 0, "platforms": ["pc", "steam", "epic-games-store", "ps4", "ps5", "xbox-one", "xbox-series-xs"], "types": ["game"], "pingRoleID": 0, "minimumWorth": 0, "hideUnrated": False, "includeExpired": False, "maxPostsPerCheck": 5},
     "movieNight": {"enabled": False, "channelID": 0, "pingRoleID": 0},
     "relay": {"enabled": False, "destinationGuildID": 0, "messages": True, "edits": True,
               "deletes": True, "reactions": True, "channelRoutes": []},
@@ -156,8 +156,28 @@ class CommunitySuite(commands.Cog):
     def filtered_games(self, games, settings):
         platforms = {str(value).lower() for value in settings.get("platforms", [])}
         types = {str(value).lower() for value in settings.get("types", [])}
-        return [game for game in games if (not platforms or any(platform in str(game.get("platforms", "")).lower() for platform in platforms))
-                and (not types or str(game.get("type", "")).lower() in types)]
+        minimum_worth = max(0.0, float(settings.get("minimumWorth", 0) or 0))
+        now = datetime.now(timezone.utc)
+
+        def worth(game):
+            match = re.search(r"\d+(?:\.\d+)?", str(game.get("worth") or "0").replace(",", ""))
+            return float(match.group()) if match else 0.0
+
+        def active(game):
+            if settings.get("includeExpired") or not game.get("end_date"):
+                return True
+            try:
+                end = datetime.strptime(game["end_date"], "%Y-%m-%d %H:%M:%S").replace(tzinfo=timezone.utc)
+                return end > now
+            except (TypeError, ValueError):
+                return True
+
+        return [game for game in games
+                if (not platforms or any(platform in str(game.get("platforms", "")).lower() for platform in platforms))
+                and (not types or str(game.get("type", "")).lower() in types)
+                and worth(game) >= minimum_worth
+                and (not settings.get("hideUnrated") or worth(game) > 0)
+                and active(game)]
 
     @tasks.loop(minutes=15)
     async def free_game_check(self):
@@ -173,7 +193,9 @@ class CommunitySuite(commands.Cog):
                 seen = set(json.loads(GAME_STATE_FILE.read_text()).get("seen", []))
             except (OSError, ValueError, TypeError):
                 seen = {str(game.get("id")) for game in games}
-            for game in reversed([item for item in games if str(item.get("id")) not in seen]):
+            unseen = [item for item in games if str(item.get("id")) not in seen]
+            post_limit = min(20, max(1, int(settings.get("maxPostsPerCheck", 5) or 5)))
+            for game in reversed(unseen[:post_limit]):
                 await self.post_game(channel, game, settings)
             seen.update(str(game.get("id")) for game in games)
             GAME_STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
@@ -193,12 +215,18 @@ class CommunitySuite(commands.Cog):
         embed = discord.Embed(title=title, url=url, description=description, color=discord.Color.green())
         embed.add_field(name="Platforms", value=str(game.get("platforms", "Unknown"))[:1024])
         embed.add_field(name="Normal price", value=str(game.get("worth") or "Unknown"))
-        embed.add_field(name="Ends", value=str(game.get("end_date") or "While supplies last"))
+        try:
+            end_time = datetime.strptime(str(game.get("end_date")), "%Y-%m-%d %H:%M:%S").replace(tzinfo=timezone.utc)
+            end_label = discord.utils.format_dt(end_time, "R")
+        except (TypeError, ValueError):
+            end_label = "While supplies last"
+        embed.add_field(name="Ends", value=end_label)
         if game.get("image") or game.get("thumbnail"):
             embed.set_image(url=game.get("image") or game.get("thumbnail"))
         embed.add_field(name="Source", value="[Giveaway data from GamerPower](https://www.gamerpower.com/)", inline=False)
         role_id = int(settings.get("pingRoleID") or 0); role = channel.guild.get_role(role_id)
-        await channel.send(content=role.mention if role else None, embed=embed, allowed_mentions=discord.AllowedMentions(roles=True))
+        mentions = discord.AllowedMentions(roles=[role] if role else False, users=False, everyone=False)
+        await channel.send(content=role.mention if role else None, embed=embed, allowed_mentions=mentions)
 
     @staticmethod
     def _staff(member: discord.Member, settings: dict) -> bool:
@@ -506,6 +534,19 @@ class CommunitySuite(commands.Cog):
         embed = discord.Embed(title="Free games available now", description="\n".join(lines)[:4000], color=discord.Color.green())
         embed.add_field(name="Source", value="[Giveaway data from GamerPower](https://www.gamerpower.com/)")
         await interaction.followup.send(embed=embed, ephemeral=True)
+
+    @games.command(name="status", description="Show how free-game alerts are configured")
+    async def games_status(self, interaction: discord.Interaction):
+        settings = self.settings()["freeGames"]
+        channel = interaction.guild.get_channel(int(settings.get("channelID") or 0))
+        embed = discord.Embed(title="Free-game alerts", color=discord.Color.green())
+        embed.add_field(name="Automatic alerts", value="On" if settings.get("enabled") else "Off")
+        embed.add_field(name="Channel", value=channel.mention if channel else "Not selected")
+        embed.add_field(name="Platforms", value=", ".join(settings.get("platforms", [])) or "All", inline=False)
+        embed.add_field(name="Offer types", value=", ".join(settings.get("types", [])) or "All")
+        embed.add_field(name="Minimum normal price", value=f"${float(settings.get('minimumWorth', 0) or 0):.2f}")
+        embed.set_footer(text="Giveaway data provided by GamerPower")
+        await interaction.response.send_message(embed=embed, ephemeral=True)
 
     movie = app_commands.Group(name="movie", description="Plan a server movie night", guild_ids=[cfg.guild_id])
 

--- a/cogs/community_suite.py
+++ b/cogs/community_suite.py
@@ -32,6 +32,8 @@ DATA_FILE = Path(os.environ.get(
     str(Path.home() / "Library/Application Support/SowensServer/GIRRuntime/dashboard/data/community.json"),
 ))
 GAME_STATE_FILE = DATA_FILE.with_name("free-games-state.json")
+GAME_STATUS_FILE = DATA_FILE.with_name("free-games-status.json")
+GAME_REQUEST_FILE = DATA_FILE.with_name("free-games-request.json")
 GAME_API = "https://www.gamerpower.com/api/giveaways"
 EPIC_API = "https://store-site-backend-static.ak.epicgames.com/freeGamesPromotions?locale=en-US&country=US&allowCountries=US"
 CHEAPSHARK_API = "https://www.cheapshark.com/api/1.0/deals?upperPrice=0&onSale=1&pageSize=60&sortBy=Recent"
@@ -95,11 +97,14 @@ class CommunitySuite(commands.Cog):
         self.afk = {}
         self.relay_queue = asyncio.Queue(maxsize=10000)
         self.game_provider_health = {}
+        self.game_check_lock = asyncio.Lock()
         self.relay_worker = asyncio.create_task(self._relay_worker())
         self.free_game_check.start()
+        self.free_game_request_check.start()
 
     def cog_unload(self):
         self.free_game_check.cancel()
+        self.free_game_request_check.cancel()
         self.relay_worker.cancel()
 
     def settings(self):
@@ -267,8 +272,24 @@ class CommunitySuite(commands.Cog):
         minutes = min(1440, max(5, int(settings.get("checkMinutes", 15) or 15)))
         if self.free_game_check.minutes != minutes:
             self.free_game_check.change_interval(minutes=minutes)
+        await self.run_free_game_check(settings)
+
+    def _save_game_status(self, state, **details):
+        now = datetime.now(timezone.utc)
+        payload = {"state": state, "updatedAt": int(now.timestamp()), "providerHealth": self.game_provider_health, **details}
+        GAME_STATUS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        temporary = GAME_STATUS_FILE.with_suffix(".tmp")
+        temporary.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+        temporary.replace(GAME_STATUS_FILE)
+        return payload
+
+    async def run_free_game_check(self, settings=None, *, manual=False):
+        settings = settings or self.settings()["freeGames"]
         if not settings.get("enabled"):
-            return
+            return self._save_game_status("disabled", message="Automatic free-game alerts are off")
+        if self.game_check_lock.locked():
+            return self._save_game_status("busy", message="A free-game check is already running")
+        minutes = min(1440, max(5, int(settings.get("checkMinutes", 15) or 15)))
         channel = self.bot.get_channel(int(settings.get("channelID") or 0))
         if not channel:
             preferred = {"free-games", "freebies", "game-deals", "giveaways"}
@@ -276,26 +297,62 @@ class CommunitySuite(commands.Cog):
             channel = next((item for item in getattr(guild, "text_channels", []) if item.name.lower() in preferred), None)
         if not channel:
             logger.warning("Free-game alerts are enabled but no valid alert channel is available")
-            return
-        try:
-            games = self.filtered_games(await self.fetch_free_games(settings), settings)
+            return self._save_game_status("failed", message="No valid free-game channel is available")
+        async with self.game_check_lock:
+            started = datetime.now(timezone.utc)
+            self._save_game_status("checking", startedAt=int(started.timestamp()), channelID=channel.id)
             try:
-                seen = set(json.loads(GAME_STATE_FILE.read_text()).get("seen", []))
-            except (OSError, ValueError, TypeError):
-                seen = {str(game.get("id")) for game in games}
-            unseen = [item for item in games if str(item.get("id")) not in seen]
-            post_limit = min(20, max(1, int(settings.get("maxPostsPerCheck", 5) or 5)))
-            for game in reversed(unseen[:post_limit]):
-                await self.post_game(channel, game, settings)
-            seen.update(str(game.get("id")) for game in games)
-            GAME_STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
-            temporary = GAME_STATE_FILE.with_suffix(".tmp")
-            temporary.write_text(json.dumps({"seen": sorted(seen)[-2000:]}) + "\n"); temporary.replace(GAME_STATE_FILE)
-        except Exception:
-            logger.exception("Free game check failed")
+                games = self.filtered_games(await self.fetch_free_games(settings), settings)
+                try:
+                    saved = json.loads(GAME_STATE_FILE.read_text())
+                    seen = set(saved.get("seen", [])); history = list(saved.get("history", []))
+                except (OSError, ValueError, TypeError):
+                    seen = {str(game.get("id")) for game in games}; history = []
+                unseen = [item for item in games if str(item.get("id")) not in seen]
+                post_limit = min(20, max(1, int(settings.get("maxPostsPerCheck", 5) or 5)))
+                posted = []
+                for game in reversed(unseen[:post_limit]):
+                    await self.post_game(channel, game, settings)
+                    record = {"id": str(game.get("id")), "title": str(game.get("title", "Free game"))[:256],
+                              "source": str(game.get("source", "Unknown")), "channelID": channel.id,
+                              "postedAt": int(datetime.now(timezone.utc).timestamp())}
+                    posted.append(record); history.insert(0, record)
+                seen.update(str(game.get("id")) for game in games)
+                GAME_STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+                temporary = GAME_STATE_FILE.with_suffix(".tmp")
+                temporary.write_text(json.dumps({"seen": sorted(seen)[-4000:], "history": history[:250]}, indent=2) + "\n")
+                temporary.replace(GAME_STATE_FILE)
+                finished = datetime.now(timezone.utc)
+                return self._save_game_status("complete", startedAt=int(started.timestamp()), lastCheck=int(finished.timestamp()),
+                    nextCheck=int(finished.timestamp()) + minutes * 60, durationMs=int((finished - started).total_seconds() * 1000),
+                    channelID=channel.id, offersFound=len(games), newOffers=len(unseen), posted=len(posted), manual=manual)
+            except Exception as error:
+                logger.exception("Free game check failed")
+                return self._save_game_status("failed", startedAt=int(started.timestamp()), lastCheck=int(time.time()),
+                                              channelID=channel.id, message=str(error)[:300], manual=manual)
 
     @free_game_check.before_loop
     async def before_free_game_check(self):
+        await self.bot.wait_until_ready()
+
+    @tasks.loop(seconds=10)
+    async def free_game_request_check(self):
+        try:
+            request = json.loads(GAME_REQUEST_FILE.read_text())
+        except (OSError, ValueError, TypeError):
+            return
+        if request.get("state") != "requested":
+            return
+        request["state"] = "working"; request["startedAt"] = int(time.time())
+        temporary = GAME_REQUEST_FILE.with_suffix(".tmp")
+        temporary.write_text(json.dumps(request, indent=2) + "\n"); temporary.replace(GAME_REQUEST_FILE)
+        result = await self.run_free_game_check(manual=True)
+        request.update({"state": "complete" if result.get("state") == "complete" else result.get("state", "failed"),
+                        "finishedAt": int(time.time()), "result": result})
+        temporary.write_text(json.dumps(request, indent=2) + "\n"); temporary.replace(GAME_REQUEST_FILE)
+
+    @free_game_request_check.before_loop
+    async def before_free_game_request_check(self):
         await self.bot.wait_until_ready()
 
     @staticmethod
@@ -653,7 +710,31 @@ class CommunitySuite(commands.Cog):
         health = "\n".join(f"**{name.title()}**: {state}" for name, state in sorted(self.game_provider_health.items()))
         if health:
             embed.add_field(name="Source health", value=health[:1024], inline=False)
+        runtime = {}
+        try:
+            runtime = json.loads(GAME_STATUS_FILE.read_text())
+        except (OSError, ValueError, TypeError):
+            pass
+        if runtime.get("lastCheck"):
+            checked = datetime.fromtimestamp(runtime["lastCheck"], timezone.utc)
+            embed.add_field(name="Last check", value=f"{discord.utils.format_dt(checked, 'R')} · {runtime.get('offersFound', 0)} matches · {runtime.get('posted', 0)} posted", inline=False)
         await interaction.response.send_message(embed=embed, ephemeral=True)
+
+    @games.command(name="check", description="Check all enabled free-game sources now")
+    @app_commands.default_permissions(manage_guild=True)
+    async def games_check(self, interaction: discord.Interaction):
+        await interaction.response.defer(ephemeral=True)
+        result = await self.run_free_game_check(manual=True)
+        await interaction.followup.send(f"Check **{result['state']}** · {result.get('offersFound', 0)} matches · {result.get('posted', 0)} new posts.", ephemeral=True)
+
+    @games.command(name="preview", description="Preview the next matching free-game embed")
+    async def games_preview(self, interaction: discord.Interaction):
+        await interaction.response.defer(ephemeral=True)
+        settings = self.settings()["freeGames"]
+        games = self.filtered_games(await self.fetch_free_games(settings), settings)
+        if not games:
+            await interaction.followup.send("No matching offers are available to preview.", ephemeral=True); return
+        await interaction.followup.send(embed=self.game_embed(games[0]), ephemeral=True)
 
     movie = app_commands.Group(name="movie", description="Plan a server movie night", guild_ids=[cfg.guild_id])
 

--- a/cogs/community_suite.py
+++ b/cogs/community_suite.py
@@ -271,6 +271,11 @@ class CommunitySuite(commands.Cog):
             return
         channel = self.bot.get_channel(int(settings.get("channelID") or 0))
         if not channel:
+            preferred = {"free-games", "freebies", "game-deals", "giveaways"}
+            guild = self.bot.get_guild(cfg.guild_id)
+            channel = next((item for item in getattr(guild, "text_channels", []) if item.name.lower() in preferred), None)
+        if not channel:
+            logger.warning("Free-game alerts are enabled but no valid alert channel is available")
             return
         try:
             games = self.filtered_games(await self.fetch_free_games(settings), settings)

--- a/cogs/community_suite.py
+++ b/cogs/community_suite.py
@@ -27,7 +27,9 @@ from discord.ext import commands, tasks
 
 from utils import cfg, logger
 from utils.framework.permissions import gatekeeper
-from community_rules import caps_percent, detect_scam, has_invite, is_image_attachment, normalize_obfuscated_text, recent_count
+from community_rules import (caps_percent, detect_scam, has_hidden_invite, has_invite,
+                             has_suspicious_image_name, is_image_attachment,
+                             normalize_obfuscated_text, recent_count)
 
 
 DATA_FILE = Path(os.environ.get(
@@ -48,7 +50,8 @@ DEFAULTS = {
         "imageWindowSeconds": 20, "fastSpam": True, "messageThreshold": 7,
         "messageWindowSeconds": 8, "capsSpam": True, "capsPercent": 80,
         "mentionSpam": True, "mentionThreshold": 6, "inviteLinks": False,
-        "scamDetection": True, "scamTimeoutHours": 168,
+        "scamDetection": True, "scamTimeoutHours": 168, "hiddenInvites": True,
+        "suspiciousImageNames": True,
         "monitorAllChannels": True, "monitoredChannelIDs": [], "ignoredChannelIDs": [], "ignoredRoleIDs": [],
     },
     "reports": {"pingModeratorRole": True, "pingAdministratorRole": False, "pingRoleIDs": [],
@@ -581,15 +584,28 @@ class CommunitySuite(commands.Cog):
             await self._moderate(message, scam_rule, scam_reason)
             return
 
+        if (settings["automod"].get("hiddenInvites", True) and has_hidden_invite(message.content)
+                and not gatekeeper.has(message.guild, message.author, 1)):
+            hidden_rule = dict(settings["automod"])
+            hidden_rule.update({"deleteMessage": True, "timeoutHours": 168})
+            await self._moderate(message, hidden_rule,
+                                 "Discord invite obscured with invisible or compatibility characters")
+            return
+
         # Prevent image dumps from accounts that have not reached Member+.
         # This focused safety rule stays active when general AutoMod is off.
         image_attachments = [attachment for attachment in message.attachments
                              if is_image_attachment(attachment.content_type, attachment.filename)]
-        if len(image_attachments) >= 4 and not gatekeeper.has(message.guild, message.author, 1):
+        suspicious_names = [attachment.filename for attachment in image_attachments
+                            if has_suspicious_image_name(attachment.filename)]
+        suspicious_name = settings["automod"].get("suspiciousImageNames", True) and suspicious_names
+        if (len(image_attachments) >= 4 or suspicious_name) and not gatekeeper.has(message.guild, message.author, 1):
             image_rule = dict(settings["automod"])
             image_rule.update({"deleteMessage": True, "timeoutHours": 168})
-            await self._moderate(message, image_rule,
-                                 f"{len(image_attachments)} images in one message from a user below Member+")
+            trigger = (f"{len(image_attachments)} images in one message from a user below Member+"
+                       if len(image_attachments) >= 4 else
+                       f"Suspicious campaign image filename: {suspicious_names[0]}")
+            await self._moderate(message, image_rule, trigger)
             return
 
         if message.author.id in self.afk:
@@ -670,7 +686,34 @@ class CommunitySuite(commands.Cog):
         if guild.id == cfg.guild_id:
             self._observe_identity(user, "banned", force=True)
 
+    async def _preserve_image_evidence(self, message: discord.Message, maximum: int) -> list[discord.File]:
+        images = [item for item in message.attachments
+                  if is_image_attachment(item.content_type, item.filename)][:maximum]
+        if not images:
+            return []
+        files = []
+        timeout = aiohttp.ClientTimeout(total=12)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            for index, item in enumerate(images, 1):
+                try:
+                    async with session.get(item.url) as response:
+                        response.raise_for_status()
+                        data = await response.content.read(8 * 1024 * 1024 + 1)
+                    if len(data) > 8 * 1024 * 1024:
+                        logger.warning("Skipped oversized moderation evidence attachment %s", item.id)
+                        continue
+                    suffix = Path(item.filename).suffix.casefold()
+                    suffix = suffix if re.fullmatch(r"\.[a-z0-9]{1,10}", suffix) else ".png"
+                    files.append(discord.File(BytesIO(data), filename=f"evidence-{index}{suffix}"))
+                except (aiohttp.ClientError, asyncio.TimeoutError, ValueError):
+                    logger.warning("Could not preserve moderation evidence attachment %s", item.id)
+        return files
+
     async def _moderate(self, message: discord.Message, settings: dict, trigger: str):
+        report_settings = self.settings().get("reports", {})
+        maximum = max(1, min(4, int(report_settings.get("maxLogImages", 4))))
+        evidence = (await self._preserve_image_evidence(message, maximum)
+                    if report_settings.get("includeImages", True) else [])
         if settings.get("deleteMessage"):
             try:
                 await message.delete()
@@ -700,21 +743,27 @@ class CommunitySuite(commands.Cog):
         embed.add_field(name="Trigger", value=trigger, inline=True)
         embed.add_field(name="Action", value=action, inline=False)
         embed.add_field(name="Campaign group", value=f"`{group}` · {len(self.report_batches[group])} account(s)", inline=False)
-        report_settings = self.settings().get("reports", {})
-        if message.attachments and report_settings.get("includeImages", True):
+        if evidence:
+            embed.set_image(url=f"attachment://{evidence[0].filename}")
+        elif message.attachments and report_settings.get("includeImages", True):
             embed.set_image(url=message.attachments[0].url)
         view = discord.ui.View(timeout=None)
         view.add_item(discord.ui.Button(label="Ban", style=discord.ButtonStyle.danger, custom_id=f"gir:report:ban:{message.author.id}"))
         view.add_item(discord.ui.Button(label="Ban matching", style=discord.ButtonStyle.danger, custom_id=f"gir:report:banbatch:{group}"))
         view.add_item(discord.ui.Button(label="Dismiss", style=discord.ButtonStyle.secondary, custom_id=f"gir:report:dismiss:{message.author.id}"))
         content, mentions = self._report_mentions(message.guild)
-        maximum = max(1, min(10, int(report_settings.get("maxLogImages", 4))))
         extras = []
-        if report_settings.get("includeImages", True):
+        if evidence:
+            for item in evidence[1:]:
+                extra = discord.Embed(url=message.jump_url)
+                extra.set_image(url=f"attachment://{item.filename}")
+                extras.append(extra)
+        elif report_settings.get("includeImages", True):
             for item in message.attachments[1:maximum]:
-                if (item.content_type or "").startswith("image/"):
+                if is_image_attachment(item.content_type, item.filename):
                     extra = discord.Embed(url=message.jump_url); extra.set_image(url=item.url); extras.append(extra)
-        await channel.send(content=content, embeds=[embed, *extras], view=view, allowed_mentions=mentions)
+        await channel.send(content=content, embeds=[embed, *extras], files=evidence,
+                           view=view, allowed_mentions=mentions)
 
     @commands.Cog.listener()
     async def on_interaction(self, interaction: discord.Interaction):

--- a/cogs/community_suite.py
+++ b/cogs/community_suite.py
@@ -6,6 +6,7 @@ actions start disabled, and every automatic action can be reviewed in Discord.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import os
 import random
@@ -26,7 +27,7 @@ from discord.ext import commands, tasks
 
 from utils import cfg, logger
 from utils.framework.permissions import gatekeeper
-from community_rules import caps_percent, detect_scam, has_invite, is_image_attachment, recent_count
+from community_rules import caps_percent, detect_scam, has_invite, is_image_attachment, normalize_obfuscated_text, recent_count
 
 
 DATA_FILE = Path(os.environ.get(
@@ -53,7 +54,9 @@ DEFAULTS = {
     "reports": {"pingModeratorRole": True, "pingAdministratorRole": False, "pingRoleIDs": [],
                 "pingUserIDs": [], "allowEveryone": True, "allowedRoleIDs": [], "allowedUserIDs": [],
                 "ignoredUserIDs": [], "ignoredMessageIDs": [], "ignoredChannelIDs": [],
-                "ignoredThreadIDs": [], "joinThreadsWhenMentioned": True, "notifyOnIgnoredPing": False},
+                "ignoredThreadIDs": [], "joinThreadsWhenMentioned": True, "notifyOnIgnoredPing": False,
+                "includeImages": True, "maxLogImages": 4, "reportCooldownSeconds": 45,
+                "batchBanMax": 50, "batchBanDelayMs": 1100, "detectInvisibleCharacters": True},
     "identityHistory": {"enabled": True, "refreshMinutes": 15, "storeUsernames": True,
                         "storeDisplayNames": True, "storeAvatarHashes": True, "storeRoles": True},
     "welcome": {"enabled": False, "channelID": 0, "message": "Welcome {mention} to {server}!", "goodbyeEnabled": False, "goodbyeMessage": "{name} left the server."},
@@ -107,6 +110,8 @@ class CommunitySuite(commands.Cog):
         self.game_provider_health = {}
         self.game_check_lock = asyncio.Lock()
         self.identity_observed = {}
+        self.recent_reports = {}
+        self.report_batches = defaultdict(set)
         self.relay_worker = asyncio.create_task(self._relay_worker())
         self.free_game_check.start()
         self.free_game_request_check.start()
@@ -554,7 +559,8 @@ class CommunitySuite(commands.Cog):
             "jumpURL": message.jump_url, "attachments": [item.url for item in message.attachments]})
         settings = self.settings()
         self._observe_identity(message.author)
-        lowered = message.content.lower().strip()
+        visible_content = normalize_obfuscated_text(message.content) if settings.get("reports", {}).get("detectInvisibleCharacters", True) else message.content
+        lowered = visible_content.lower().strip()
 
         if (isinstance(message.channel, discord.Thread) and self.bot.user in message.mentions
                 and settings.get("reports", {}).get("joinThreadsWhenMentioned", True)):
@@ -568,7 +574,7 @@ class CommunitySuite(commands.Cog):
             return
 
         attachment_text = " ".join(f"{item.filename} {getattr(item, 'description', '') or ''}" for item in message.attachments)
-        scam_reason = detect_scam(f"{message.content} {attachment_text}")
+        scam_reason = detect_scam(f"{visible_content} {attachment_text}")
         if settings["automod"].get("scamDetection", True) and scam_reason and not gatekeeper.has(message.guild, message.author, 1):
             scam_rule = dict(settings["automod"])
             scam_rule.update({"deleteMessage": True, "timeoutHours": int(scam_rule.get("scamTimeoutHours", 168))})
@@ -648,7 +654,7 @@ class CommunitySuite(commands.Cog):
             findings.append("mostly capital letters")
         if auto.get("mentionSpam") and len(message.mentions) + len(message.role_mentions) >= int(auto.get("mentionThreshold", 6)):
             findings.append("too many mentions")
-        if auto.get("inviteLinks") and has_invite(message.content):
+        if auto.get("inviteLinks") and has_invite(visible_content):
             findings.append("Discord invite link")
         if findings:
             await self._moderate(message, auto, findings[0])
@@ -681,18 +687,34 @@ class CommunitySuite(commands.Cog):
         channel = self._report_channel(message.guild)
         if not channel:
             return
+        group = hashlib.sha256(trigger.casefold().encode()).hexdigest()[:16]
+        self.report_batches[group].add(message.author.id)
+        cooldown = max(0, min(3600, int(self.settings().get("reports", {}).get("reportCooldownSeconds", 45))))
+        report_key = (message.author.id, group)
+        if time.monotonic() - self.recent_reports.get(report_key, 0) < cooldown:
+            return
+        self.recent_reports[report_key] = time.monotonic()
         embed = discord.Embed(title="🚨 Automatic moderation alert", color=discord.Color.red(), timestamp=datetime.now(timezone.utc))
         embed.add_field(name="Member", value=f"{message.author.mention}\n`{message.author.id}`", inline=False)
         embed.add_field(name="Channel", value=message.channel.mention, inline=True)
         embed.add_field(name="Trigger", value=trigger, inline=True)
         embed.add_field(name="Action", value=action, inline=False)
-        if message.attachments:
+        embed.add_field(name="Campaign group", value=f"`{group}` · {len(self.report_batches[group])} account(s)", inline=False)
+        report_settings = self.settings().get("reports", {})
+        if message.attachments and report_settings.get("includeImages", True):
             embed.set_image(url=message.attachments[0].url)
         view = discord.ui.View(timeout=None)
         view.add_item(discord.ui.Button(label="Ban", style=discord.ButtonStyle.danger, custom_id=f"gir:report:ban:{message.author.id}"))
+        view.add_item(discord.ui.Button(label="Ban matching", style=discord.ButtonStyle.danger, custom_id=f"gir:report:banbatch:{group}"))
         view.add_item(discord.ui.Button(label="Dismiss", style=discord.ButtonStyle.secondary, custom_id=f"gir:report:dismiss:{message.author.id}"))
         content, mentions = self._report_mentions(message.guild)
-        await channel.send(content=content, embed=embed, view=view, allowed_mentions=mentions)
+        maximum = max(1, min(10, int(report_settings.get("maxLogImages", 4))))
+        extras = []
+        if report_settings.get("includeImages", True):
+            for item in message.attachments[1:maximum]:
+                if (item.content_type or "").startswith("image/"):
+                    extra = discord.Embed(url=message.jump_url); extra.set_image(url=item.url); extras.append(extra)
+        await channel.send(content=content, embeds=[embed, *extras], view=view, allowed_mentions=mentions)
 
     @commands.Cog.listener()
     async def on_interaction(self, interaction: discord.Interaction):
@@ -700,12 +722,42 @@ class CommunitySuite(commands.Cog):
         if not custom_id.startswith("gir:report:"):
             return
         _, _, action, user_id = custom_id.split(":", 3)
+        if action == "banbatch":
+            if not interaction.user.guild_permissions.ban_members:
+                await interaction.response.send_message("You need permission to ban members to use this.", ephemeral=True); return
+            report_settings = self.settings().get("reports", {})
+            target_set = set(self.report_batches.get(user_id, set()))
+            if not target_set:
+                async for report_message in interaction.channel.history(limit=500):
+                    for report_embed in report_message.embeds:
+                        fields = {field.name: field.value for field in report_embed.fields}
+                        if f"`{user_id}`" in fields.get("Campaign group", ""):
+                            match = re.search(r"`(\d{15,22})`", fields.get("Member", ""))
+                            if match: target_set.add(int(match.group(1)))
+            targets = list(target_set)[:max(1, min(100, int(report_settings.get("batchBanMax", 50))))]
+            if not targets:
+                await interaction.response.send_message("No matching accounts remain in this active campaign group.", ephemeral=True); return
+            await interaction.response.defer(ephemeral=True); banned, failed = 0, 0
+            delay = max(250, min(5000, int(report_settings.get("batchBanDelayMs", 1100)))) / 1000
+            for target in targets:
+                try:
+                    await interaction.guild.ban(discord.Object(id=target), reason=f"Matching AutoMod campaign reviewed by {interaction.user}")
+                    banned += 1
+                except discord.HTTPException:
+                    failed += 1
+                await asyncio.sleep(delay)
+            await interaction.followup.send(f"Batch review complete: **{banned} banned**, **{failed} failed**. Campaign `{user_id}`.", ephemeral=True)
+            embed = interaction.message.embeds[0]; embed.add_field(name="Batch review", value=f"{interaction.user.mention}: {banned} banned, {failed} failed", inline=False)
+            await interaction.message.edit(embed=embed, view=None)
+            return
         if action == "ban":
             if not interaction.user.guild_permissions.ban_members:
                 await interaction.response.send_message("You need permission to ban members to use this.", ephemeral=True); return
             try:
                 await interaction.guild.ban(discord.Object(id=int(user_id)), reason=f"Reviewed AutoMod report by {interaction.user}")
-                await interaction.response.edit_message(content=f"Banned by {interaction.user.mention}", view=None)
+                embed = interaction.message.embeds[0]
+                embed.add_field(name="Review outcome", value=f"Banned by {interaction.user.mention}\nCause: {next((f.value for f in embed.fields if f.name == 'Trigger'), 'reported message')}", inline=False)
+                await interaction.response.edit_message(content=f"Banned by {interaction.user.mention}", embed=embed, view=None)
             except discord.Forbidden:
                 await interaction.response.send_message("Discord would not allow that ban. Check GIR's Ban Members permission and role position.", ephemeral=True)
         else:

--- a/cogs/community_suite.py
+++ b/cogs/community_suite.py
@@ -6,16 +6,14 @@ actions start disabled, and every automatic action can be reviewed in Discord.
 from __future__ import annotations
 
 import asyncio
-import hashlib
 import json
 import os
 import random
 import re
 import zipfile
-import xml.etree.ElementTree as ET
 from io import BytesIO
 import time
-from urllib.parse import quote, urlparse
+from urllib.parse import quote
 from collections import defaultdict, deque
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -39,10 +37,6 @@ GAME_REQUEST_FILE = DATA_FILE.with_name("free-games-request.json")
 GAME_API = "https://www.gamerpower.com/api/giveaways"
 EPIC_API = "https://store-site-backend-static.ak.epicgames.com/freeGamesPromotions?locale=en-US&country=US&allowCountries=US"
 CHEAPSHARK_API = "https://www.cheapshark.com/api/1.0/deals?onSale=1&pageSize=60&sortBy=Savings"
-DEFAULT_GAME_FEEDS = [
-    "https://www.reddit.com/r/FreeGameFindings+FreeGamesOnSteam+GameDeals/.rss?limit=75",
-    "https://www.gamerpower.com/rss/pc",
-]
 
 DEFAULTS = {
     "automod": {
@@ -57,7 +51,7 @@ DEFAULTS = {
     "autorole": {"enabled": False, "roleIDs": []},
     "starboard": {"enabled": False, "channelID": 0, "threshold": 3, "emoji": "⭐"},
     "suggestions": {"enabled": False, "channelID": 0},
-    "freeGames": {"enabled": False, "channelID": 0, "platforms": ["pc", "steam", "epic-games-store", "ps4", "ps5", "xbox-one", "xbox-series-xs"], "types": ["game"], "sources": ["gamerpower", "epic", "cheapshark", "communityFeeds"], "communityFeedURLs": DEFAULT_GAME_FEEDS, "twitterAccounts": ["EpicGames", "GamerPowercom", "FreeGameFinding", "just_free_games", "CDKeys_com", "G2A_com"], "twitterBridge": "https://rsshub.app", "offerMode": "both", "minimumDiscountPercent": 50, "checkMinutes": 15, "pingRoleID": 0, "minimumWorth": 0, "hideUnrated": False, "includeExpired": False, "maxPostsPerCheck": 5},
+    "freeGames": {"enabled": False, "channelID": 0, "platforms": ["pc", "steam", "epic-games-store", "ps4", "ps5", "xbox-one", "xbox-series-xs"], "types": ["game"], "sources": ["gamerpower", "epic", "cheapshark"], "offerMode": "both", "minimumDiscountPercent": 50, "checkMinutes": 15, "pingRoleID": 0, "minimumWorth": 0, "hideUnrated": False, "includeExpired": False, "maxPostsPerCheck": 5},
     "movieNight": {"enabled": False, "channelID": 0, "pingRoleID": 0},
     "relay": {"enabled": False, "destinationGuildID": 0, "messages": True, "edits": True,
               "deletes": True, "reactions": True, "channelRoutes": []},
@@ -171,42 +165,6 @@ class CommunitySuite(commands.Cog):
             logger.warning("Free-game provider %s failed: %s", name, error)
             return name, error
 
-    async def _fetch_game_feed(self, session, name, url):
-        try:
-            async with session.get(url, timeout=aiohttp.ClientTimeout(total=20)) as response:
-                response.raise_for_status(); root = ET.fromstring(await response.text())
-            games = []
-            for node in list(root.findall(".//item"))[:40] + list(root.findall("{*}entry"))[:40]:
-                def value(*tags):
-                    for tag in tags:
-                        child = node.find(tag)
-                        if child is not None:
-                            return child.get("href") or child.text or ""
-                    return ""
-                title = re.sub(r"<[^>]+>", "", value("title", "{*}title")).strip()
-                detail = re.sub(r"<[^>]+>", "", value("description", "{*}summary", "{*}content")).strip()
-                searchable = (title + " " + detail).lower()
-                category = node.find("{*}category")
-                subreddit = str(category.get("term", "")) if category is not None else ""
-                if (subreddit.lower() == "gamedeals" or name == "Reddit GameDeals" or name.startswith("X @")) and not re.search(r"\b(free|giveaway|sale|deal|discount|save)\b|\d+% off|\$0\.00", searchable):
-                    continue
-                link = value("link", "{*}link")
-                identifier = value("guid", "{*}id") or link or title
-                platform = ("Steam, PC" if "steam" in searchable else "Epic Games Store, PC" if "epic" in searchable
-                            else "PlayStation 5, PlayStation 4" if re.search(r"\b(ps5|ps4|playstation)\b", searchable)
-                            else "Xbox Series X/S, Xbox One" if "xbox" in searchable else "Nintendo Switch" if "switch" in searchable else "PC")
-                offer_type = "loot" if re.search(r"\b(dlc|pack|loot|skin|key)\b", searchable) else "game"
-                percent = re.search(r"(\d{1,3})%\s*off", searchable)
-                games.append({"id": f"feed:{hashlib.sha256(identifier.encode()).hexdigest()}", "title": title,
-                    "description": detail[:900], "platforms": platform, "type": offer_type, "worth": "Unknown",
-                    "salePrice": 0 if re.search(r"\b(free|giveaway)\b|\$0\.00|100% off", searchable) else None,
-                    "discountPercent": int(percent.group(1)) if percent else 0,
-                    "end_date": None, "open_giveaway_url": link, "source": f"Reddit r/{subreddit}" if subreddit else name, "source_url": url})
-            return name, games
-        except (aiohttp.ClientError, asyncio.TimeoutError, ValueError, ET.ParseError) as error:
-            logger.warning("Free-game feed %s failed: %s", name, error)
-            return name, error
-
     @staticmethod
     def _epic_games(payload):
         rows = payload.get("data", {}).get("Catalog", {}).get("searchStore", {}).get("elements", [])
@@ -261,30 +219,10 @@ class CommunitySuite(commands.Cog):
 
     async def fetch_free_games(self, settings=None):
         settings = settings or {}
-        enabled = set(settings.get("sources") or ["gamerpower", "epic", "cheapshark", "communityFeeds"])
+        enabled = set(settings.get("sources") or ["gamerpower", "epic", "cheapshark"])
         urls = {"gamerpower": GAME_API + "?sort-by=date", "epic": EPIC_API, "cheapshark": CHEAPSHARK_API}
         async with aiohttp.ClientSession(headers={"User-Agent": "GIR Discord Bot/1.0"}) as session:
             results = await asyncio.gather(*(self._fetch_json(session, name, url) for name, url in urls.items() if name in enabled))
-            feed_jobs = []
-            if "communityFeeds" in enabled:
-                for url in settings.get("communityFeedURLs") or DEFAULT_GAME_FEEDS:
-                    if "FreeGameFindings+" in url: name = "Reddit free-game communities"
-                    elif "FreeGameFindings" in url: name = "Reddit FreeGameFindings"
-                    elif "FreeGamesOnSteam" in url: name = "Reddit FreeGamesOnSteam"
-                    elif "GameDeals" in url: name = "Reddit GameDeals"
-                    elif "gamerpower.com" in url: name = "GamerPower RSS"
-                    else: name = urlparse(url).hostname or "Community feed"
-                    feed_jobs.append(self._fetch_game_feed(session, name, url))
-                bridge = str(settings.get("twitterBridge") or "https://rsshub.app").rstrip("/")
-                for account in settings.get("twitterAccounts") or []:
-                    feed_jobs.append(self._fetch_game_feed(session, f"X @{account}", f"{bridge}/twitter/user/{quote(str(account).lstrip('@'))}"))
-            feed_results = await asyncio.gather(*feed_jobs)
-            failed_x = [name.removeprefix("X @") for name, payload in feed_results if name.startswith("X @") and isinstance(payload, Exception)]
-            if failed_x:
-                fallback_jobs = [self._fetch_game_feed(session, f"X @{account} via news RSS",
-                    "https://news.google.com/rss/search?q=" + quote(f"site:x.com/{account} (free OR giveaway OR sale OR deal)") + "&hl=en-US&gl=US&ceid=US:en")
-                    for account in failed_x]
-                feed_results.extend(await asyncio.gather(*fallback_jobs))
         games = []
         for name, payload in results:
             if isinstance(payload, Exception):
@@ -298,11 +236,6 @@ class CommunitySuite(commands.Cog):
                 games.extend(self._epic_games(payload))
             elif name == "cheapshark":
                 games.extend(self._cheapshark_games(payload))
-        for name, payload in feed_results:
-            if isinstance(payload, Exception):
-                self.game_provider_health[name] = "Unavailable"
-            else:
-                self.game_provider_health[name] = f"OK · {len(payload)} matches"; games.extend(payload)
         return self._dedupe_games(games)
 
     def filtered_games(self, games, settings):
@@ -325,7 +258,7 @@ class CommunitySuite(commands.Cog):
         def offer_matches(game):
             source = str(game.get("source", "")).lower()
             text = " ".join(str(game.get(key, "")) for key in ("title", "description")).lower()
-            free = game.get("salePrice") == 0 or source in {"gamerpower", "epic games store", "gamerpower rss"} or "freegamefindings" in source or "freegamesonsteam" in source or bool(re.search(r"\b(free|giveaway)\b|\$0\.00|100% off", text))
+            free = game.get("salePrice") == 0 or source in {"gamerpower", "epic games store"} or bool(re.search(r"\b(free|giveaway)\b|\$0\.00|100% off", text))
             discounted = float(game.get("discountPercent") or 0) >= minimum_discount
             return free if offer_mode == "free" else discounted and not free if offer_mode == "discounts" else free or discounted
 

--- a/cogs/community_suite.py
+++ b/cogs/community_suite.py
@@ -483,8 +483,17 @@ class CommunitySuite(commands.Cog):
                 break
         for item in settings.get("autoResponses", []):
             trigger = str(item.get("trigger", "")).lower().strip()
-            if item.get("enabled", True) and trigger and trigger in lowered:
-                await message.channel.send(str(item.get("response", ""))[:2000], reference=message, mention_author=False)
+            allowed_channels = {int(value) for value in item.get("channelIDs", []) if str(value).isdigit()}
+            message_channels = {message.channel.id, int(getattr(message.channel, "parent_id", 0) or 0)}
+            if (item.get("enabled", True) and trigger and trigger in lowered
+                    and (not allowed_channels or allowed_channels & message_channels)):
+                emoji_text = str(item.get("emojiText", ""))[:100]
+                content = " ".join(value for value in (emoji_text, str(item.get("response", ""))[:1900]) if value).strip()
+                sticker = message.guild.get_sticker(int(item.get("stickerID", 0) or 0))
+                send_options = {"reference": message, "mention_author": False}
+                if sticker:
+                    send_options["stickers"] = [sticker]
+                await message.channel.send(content or None, **send_options)
                 break
 
         auto = settings["automod"]

--- a/cogs/community_suite.py
+++ b/cogs/community_suite.py
@@ -366,28 +366,65 @@ class CommunitySuite(commands.Cog):
         await self.bot.wait_until_ready()
 
     @staticmethod
+    def _game_platform(game):
+        platforms = str(game.get("platforms", "")).lower()
+        choices = (("steam", "Steam", "https://store.steampowered.com/search/?term="),
+                   ("epic", "Epic Games Store", "https://store.epicgames.com/browse?q="),
+                   ("gog", "GOG", "https://www.gog.com/en/games?query="),
+                   ("xbox", "Xbox", "https://www.xbox.com/search/results?q="),
+                   ("playstation", "PlayStation", "https://store.playstation.com/search/"),
+                   ("switch", "Nintendo Switch", "https://www.nintendo.com/us/search/#q="),
+                   ("itch", "itch.io", "https://itch.io/search?q="))
+        for needle, label, search in choices:
+            if needle in platforms:
+                return label, search + quote(str(game.get("title", "")))
+        return "PC and console", None
+
+    @staticmethod
+    def _claim_kind(game):
+        text = " ".join(str(game.get(key, "")) for key in ("title", "description", "instructions")).lower()
+        temporary = ("free weekend", "free week", "free to play until", "play for free", "open beta", "playtest")
+        return "Free to play" if any(phrase in text for phrase in temporary) else "Free to keep"
+
+    @staticmethod
     def game_embed(game):
         title = str(game.get("title", "Free game"))[:256]
-        description = str(game.get("description", ""))[:2800]
         url = game.get("open_giveaway_url") or game.get("gamerpower_url") or "https://www.gamerpower.com/"
-        embed = discord.Embed(title=title, url=url, description=description, color=discord.Color.green())
-        embed.add_field(name="Platforms", value=str(game.get("platforms", "Unknown"))[:1024])
-        embed.add_field(name="Normal price", value=str(game.get("worth") or "Unknown"))
         end_time = CommunitySuite._game_date(game.get("end_date"))
-        end_label = discord.utils.format_dt(end_time, "R") if end_time else "While supplies last"
-        embed.add_field(name="Ends", value=end_label)
+        until = f" until {discord.utils.format_dt(end_time, 'd')}" if end_time else " while available"
+        claim_kind = CommunitySuite._claim_kind(game)
+        platform, _ = CommunitySuite._game_platform(game)
+        description = f"**{claim_kind}**{until}\n\n{str(game.get('description', '')).strip()[:700]}".strip()
+        embed = discord.Embed(title=title, url=url, description=description, color=discord.Color.from_rgb(88, 101, 242))
+        embed.set_author(name=platform)
         if game.get("image") or game.get("thumbnail"):
             embed.set_image(url=game.get("image") or game.get("thumbnail"))
         source = str(game.get("source") or "Giveaway source")
-        source_url = str(game.get("source_url") or url)
-        embed.add_field(name="Source", value=f"[{source}]({source_url})", inline=False)
+        worth = str(game.get("worth") or "").strip()
+        users = int(game.get("users") or 0)
+        footer = f"via {source}"
+        if worth and worth.lower() != "unknown":
+            footer += f" · Usually {worth}"
+        if users:
+            footer += f" · {users:,} claimed"
+        embed.set_footer(text=footer[:2048])
         return embed
+
+    @staticmethod
+    def game_view(game):
+        browser_url = str(game.get("open_giveaway_url") or game.get("gamerpower_url") or game.get("source_url") or "https://www.gamerpower.com/")
+        platform, store_url = CommunitySuite._game_platform(game)
+        view = discord.ui.View(timeout=None)
+        view.add_item(discord.ui.Button(label="Open in browser ↗", style=discord.ButtonStyle.link, url=browser_url[:512]))
+        if store_url and store_url != browser_url:
+            view.add_item(discord.ui.Button(label=f"Open in {platform} ↗"[:80], style=discord.ButtonStyle.link, url=store_url[:512]))
+        return view
 
     async def post_game(self, channel, game, settings):
         embed = self.game_embed(game)
         role_id = int(settings.get("pingRoleID") or 0); role = channel.guild.get_role(role_id)
         mentions = discord.AllowedMentions(roles=[role] if role else False, users=False, everyone=False)
-        await channel.send(content=role.mention if role else None, embed=embed, allowed_mentions=mentions)
+        await channel.send(content=role.mention if role else None, embed=embed, view=self.game_view(game), allowed_mentions=mentions)
 
     @staticmethod
     def _staff(member: discord.Member, settings: dict) -> bool:
@@ -744,7 +781,7 @@ class CommunitySuite(commands.Cog):
         games = self.filtered_games(await self.fetch_free_games(settings), settings)
         if not games:
             await interaction.followup.send("No matching offers are available to preview.", ephemeral=True); return
-        await interaction.followup.send(embed=self.game_embed(games[0]), ephemeral=True)
+        await interaction.followup.send(embed=self.game_embed(games[0]), view=self.game_view(games[0]), ephemeral=True)
 
     movie = app_commands.Group(name="movie", description="Plan a server movie night", guild_ids=[cfg.guild_id])
 

--- a/cogs/community_suite.py
+++ b/cogs/community_suite.py
@@ -279,6 +279,12 @@ class CommunitySuite(commands.Cog):
                 for account in settings.get("twitterAccounts") or []:
                     feed_jobs.append(self._fetch_game_feed(session, f"X @{account}", f"{bridge}/twitter/user/{quote(str(account).lstrip('@'))}"))
             feed_results = await asyncio.gather(*feed_jobs)
+            failed_x = [name.removeprefix("X @") for name, payload in feed_results if name.startswith("X @") and isinstance(payload, Exception)]
+            if failed_x:
+                fallback_jobs = [self._fetch_game_feed(session, f"X @{account} via news RSS",
+                    "https://news.google.com/rss/search?q=" + quote(f"site:x.com/{account} (free OR giveaway OR sale OR deal)") + "&hl=en-US&gl=US&ceid=US:en")
+                    for account in failed_x]
+                feed_results.extend(await asyncio.gather(*fallback_jobs))
         games = []
         for name, payload in results:
             if isinstance(payload, Exception):
@@ -475,10 +481,13 @@ class CommunitySuite(commands.Cog):
             embed.set_image(url=game.get("image") or game.get("thumbnail"))
         source = str(game.get("source") or "Giveaway source")
         worth = str(game.get("worth") or "").strip()
+        sale_price = game.get("salePrice")
         users = int(game.get("users") or 0)
         footer = f"via {source}"
         if worth and worth.lower() != "unknown":
             footer += f" · Usually {worth}"
+        if sale_price is not None and float(sale_price or 0) > 0:
+            footer += f" · Now ${float(sale_price):.2f}"
         if users:
             footer += f" · {users:,} claimed"
         embed.set_footer(text=footer[:2048])

--- a/cogs/community_suite.py
+++ b/cogs/community_suite.py
@@ -20,6 +20,7 @@ from pathlib import Path
 
 import discord
 import aiohttp
+from data.model import IdentityHistory
 from discord import app_commands
 from discord.ext import commands, tasks
 
@@ -53,6 +54,8 @@ DEFAULTS = {
                 "pingUserIDs": [], "allowEveryone": True, "allowedRoleIDs": [], "allowedUserIDs": [],
                 "ignoredUserIDs": [], "ignoredMessageIDs": [], "ignoredChannelIDs": [],
                 "ignoredThreadIDs": [], "joinThreadsWhenMentioned": True, "notifyOnIgnoredPing": False},
+    "identityHistory": {"enabled": True, "refreshMinutes": 15, "storeUsernames": True,
+                        "storeDisplayNames": True, "storeAvatarHashes": True, "storeRoles": True},
     "welcome": {"enabled": False, "channelID": 0, "message": "Welcome {mention} to {server}!", "goodbyeEnabled": False, "goodbyeMessage": "{name} left the server."},
     "autorole": {"enabled": False, "roleIDs": []},
     "starboard": {"enabled": False, "channelID": 0, "threshold": 3, "emoji": "⭐"},
@@ -103,6 +106,7 @@ class CommunitySuite(commands.Cog):
         self.relay_queue = asyncio.Queue(maxsize=10000)
         self.game_provider_health = {}
         self.game_check_lock = asyncio.Lock()
+        self.identity_observed = {}
         self.relay_worker = asyncio.create_task(self._relay_worker())
         self.free_game_check.start()
         self.free_game_request_check.start()
@@ -488,8 +492,34 @@ class CommunitySuite(commands.Cog):
         configured = int(self.settings().get("automod", {}).get("reportChannelID", 0) or 0)
         return (guild.get_channel(configured) if configured else None) or discord.utils.get(guild.text_channels, name="reports") or guild.get_channel(int(getattr(cfg.channels, "reports", 0) or 0))
 
+    def _observe_identity(self, user, status="member", force=False):
+        settings = self.settings().get("identityHistory", {})
+        if not settings.get("enabled", True) or getattr(user, "bot", False):
+            return
+        now = datetime.now(timezone.utc)
+        interval = max(1, min(1440, int(settings.get("refreshMinutes", 15)))) * 60
+        if not force and now.timestamp() - self.identity_observed.get(user.id, 0) < interval:
+            return
+        self.identity_observed[user.id] = now.timestamp()
+        names = {str(getattr(user, "name", "") or "")}
+        displays = {str(getattr(user, "global_name", "") or ""), str(getattr(user, "display_name", "") or "")}
+        avatar = getattr(getattr(user, "avatar", None), "key", None)
+        update = {"set__last_seen": now, "set__status": status, "inc__observations": 1,
+                  "set_on_insert__first_seen": now, "set_on_insert__account_created": getattr(user, "created_at", None)}
+        if settings.get("storeUsernames", True): update["add_to_set__usernames"] = next(iter(names - {""}), None)
+        if settings.get("storeDisplayNames", True): update["add_to_set__display_names"] = next(iter(displays - {""}), None)
+        if settings.get("storeAvatarHashes", True) and avatar: update["add_to_set__avatar_hashes"] = avatar
+        if settings.get("storeRoles", True) and hasattr(user, "roles"): update["set__role_ids"] = [role.id for role in user.roles]
+        if getattr(user, "joined_at", None): update["set__last_joined"] = user.joined_at
+        update = {key: value for key, value in update.items() if value is not None}
+        try:
+            IdentityHistory.objects(_id=user.id).update_one(upsert=True, **update)
+        except Exception:
+            logger.exception("Could not update identity history for %s", user.id)
+
     @commands.Cog.listener()
     async def on_member_join(self, member: discord.Member):
+        self._observe_identity(member, "member", force=True)
         settings = self.settings()
         auto = settings["autorole"]
         if auto.get("enabled"):
@@ -508,6 +538,7 @@ class CommunitySuite(commands.Cog):
 
     @commands.Cog.listener()
     async def on_member_remove(self, member: discord.Member):
+        self._observe_identity(member, "left", force=True)
         welcome = self.settings()["welcome"]
         if welcome.get("goodbyeEnabled"):
             channel = member.guild.get_channel(int(welcome.get("channelID") or 0))
@@ -522,6 +553,7 @@ class CommunitySuite(commands.Cog):
             "channel": message.channel.name, "channelID": message.channel.id, "content": message.content,
             "jumpURL": message.jump_url, "attachments": [item.url for item in message.attachments]})
         settings = self.settings()
+        self._observe_identity(message.author)
         lowered = message.content.lower().strip()
 
         if (isinstance(message.channel, discord.Thread) and self.bot.user in message.mentions
@@ -621,6 +653,16 @@ class CommunitySuite(commands.Cog):
         if findings:
             await self._moderate(message, auto, findings[0])
             self.activity[key].clear(); self.images[key].clear()
+
+    @commands.Cog.listener()
+    async def on_member_update(self, before: discord.Member, after: discord.Member):
+        if before.guild.id == cfg.guild_id:
+            self._observe_identity(after, "member", force=True)
+
+    @commands.Cog.listener()
+    async def on_member_ban(self, guild: discord.Guild, user: discord.User):
+        if guild.id == cfg.guild_id:
+            self._observe_identity(user, "banned", force=True)
 
     async def _moderate(self, message: discord.Message, settings: dict, trigger: str):
         if settings.get("deleteMessage"):

--- a/cogs/community_suite.py
+++ b/cogs/community_suite.py
@@ -1,0 +1,271 @@
+"""Modern community management tools inspired by popular general-purpose bots.
+
+The module is intentionally configured through GIR's private dashboard.  Safety
+actions start disabled, and every automatic action can be reviewed in Discord.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import time
+from collections import defaultdict, deque
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+from utils import cfg, logger
+from community_rules import caps_percent, has_invite, recent_count
+
+
+DATA_FILE = Path(os.environ.get(
+    "GIR_COMMUNITY_FILE",
+    str(Path.home() / "Library/Application Support/SowensServer/GIRRuntime/dashboard/data/community.json"),
+))
+
+DEFAULTS = {
+    "automod": {
+        "enabled": False, "reportChannelID": 0, "deleteMessage": True,
+        "timeoutHours": 168, "imageSpam": True, "imageThreshold": 4,
+        "imageWindowSeconds": 20, "fastSpam": True, "messageThreshold": 7,
+        "messageWindowSeconds": 8, "capsSpam": True, "capsPercent": 80,
+        "mentionSpam": True, "mentionThreshold": 6, "inviteLinks": False,
+        "ignoredChannelIDs": [], "ignoredRoleIDs": [],
+    },
+    "welcome": {"enabled": False, "channelID": 0, "message": "Welcome {mention} to {server}!", "goodbyeEnabled": False, "goodbyeMessage": "{name} left the server."},
+    "autorole": {"enabled": False, "roleIDs": []},
+    "starboard": {"enabled": False, "channelID": 0, "threshold": 3, "emoji": "⭐"},
+    "suggestions": {"enabled": False, "channelID": 0},
+    "customCommands": [], "autoResponses": [], "reactionRoles": [],
+}
+
+
+def _merge(base, incoming):
+    result = dict(base)
+    for key, value in incoming.items():
+        result[key] = _merge(result[key], value) if isinstance(result.get(key), dict) and isinstance(value, dict) else value
+    return result
+
+
+def load_settings():
+    try:
+        return _merge(DEFAULTS, json.loads(DATA_FILE.read_text()))
+    except (OSError, ValueError, TypeError):
+        return _merge(DEFAULTS, {})
+
+
+def render(template: str, member: discord.Member) -> str:
+    return template.replace("{mention}", member.mention).replace("{name}", member.display_name).replace("{server}", member.guild.name)
+
+
+class CommunitySuite(commands.Cog):
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+        self.activity = defaultdict(lambda: deque(maxlen=30))
+        self.images = defaultdict(lambda: deque(maxlen=30))
+        self.star_posts = {}
+
+    def settings(self):
+        return load_settings()
+
+    @staticmethod
+    def _staff(member: discord.Member, settings: dict) -> bool:
+        ignored = set(settings.get("ignoredRoleIDs", []))
+        return member.guild_permissions.manage_messages or any(role.id in ignored for role in member.roles)
+
+    @commands.Cog.listener()
+    async def on_member_join(self, member: discord.Member):
+        settings = self.settings()
+        auto = settings["autorole"]
+        if auto.get("enabled"):
+            roles = [member.guild.get_role(int(role_id)) for role_id in auto.get("roleIDs", [])]
+            roles = [role for role in roles if role and role < member.guild.me.top_role]
+            if roles:
+                try:
+                    await member.add_roles(*roles, reason="GIR automatic member role")
+                except discord.HTTPException:
+                    logger.exception("Could not assign automatic roles")
+        welcome = settings["welcome"]
+        if welcome.get("enabled"):
+            channel = member.guild.get_channel(int(welcome.get("channelID") or 0))
+            if channel:
+                await channel.send(render(str(welcome.get("message", "")), member), allowed_mentions=discord.AllowedMentions(users=True))
+
+    @commands.Cog.listener()
+    async def on_member_remove(self, member: discord.Member):
+        welcome = self.settings()["welcome"]
+        if welcome.get("goodbyeEnabled"):
+            channel = member.guild.get_channel(int(welcome.get("channelID") or 0))
+            if channel:
+                await channel.send(render(str(welcome.get("goodbyeMessage", "")), member))
+
+    @commands.Cog.listener()
+    async def on_message(self, message: discord.Message):
+        if not message.guild or message.author.bot or message.guild.id != cfg.guild_id:
+            return
+        settings = self.settings()
+        lowered = message.content.lower().strip()
+
+        for item in settings.get("customCommands", []):
+            if item.get("enabled", True) and lowered == str(item.get("trigger", "")).lower().strip():
+                await message.channel.send(str(item.get("response", ""))[:2000], reference=message, mention_author=False)
+                break
+        for item in settings.get("autoResponses", []):
+            trigger = str(item.get("trigger", "")).lower().strip()
+            if item.get("enabled", True) and trigger and trigger in lowered:
+                await message.channel.send(str(item.get("response", ""))[:2000], reference=message, mention_author=False)
+                break
+
+        auto = settings["automod"]
+        if not auto.get("enabled") or self._staff(message.author, auto) or message.channel.id in set(auto.get("ignoredChannelIDs", [])):
+            return
+        now = time.monotonic()
+        key = (message.guild.id, message.author.id)
+        self.activity[key].append(now)
+        if message.attachments and any(a.content_type and a.content_type.startswith("image/") for a in message.attachments):
+            self.images[key].extend([now] * len(message.attachments))
+        findings = []
+        window = int(auto.get("imageWindowSeconds", 20))
+        image_count = recent_count(self.images[key], now, window)
+        if auto.get("imageSpam") and image_count >= int(auto.get("imageThreshold", 4)):
+            findings.append(f"{image_count} image attachments in {window} seconds")
+        msg_window = int(auto.get("messageWindowSeconds", 8))
+        message_count = recent_count(self.activity[key], now, msg_window)
+        if auto.get("fastSpam") and message_count >= int(auto.get("messageThreshold", 7)):
+            findings.append(f"{message_count} messages in {msg_window} seconds")
+        if auto.get("capsSpam") and len(message.content) >= 20 and caps_percent(message.content) >= int(auto.get("capsPercent", 80)):
+            findings.append("mostly capital letters")
+        if auto.get("mentionSpam") and len(message.mentions) + len(message.role_mentions) >= int(auto.get("mentionThreshold", 6)):
+            findings.append("too many mentions")
+        if auto.get("inviteLinks") and has_invite(message.content):
+            findings.append("Discord invite link")
+        if findings:
+            await self._moderate(message, auto, findings[0])
+            self.activity[key].clear(); self.images[key].clear()
+
+    async def _moderate(self, message: discord.Message, settings: dict, trigger: str):
+        if settings.get("deleteMessage"):
+            try:
+                await message.delete()
+            except discord.HTTPException:
+                pass
+        hours = max(0, min(int(settings.get("timeoutHours", 0)), 336))
+        action = "Message removed"
+        if hours and isinstance(message.author, discord.Member) and message.author < message.guild.me.top_role:
+            try:
+                await message.author.timeout(datetime.now(timezone.utc) + timedelta(hours=hours), reason=f"GIR AutoMod: {trigger}")
+                action = f"Timed out for {hours} hours"
+            except discord.HTTPException:
+                action = "Message removed; timeout could not be applied"
+        report_id = int(settings.get("reportChannelID") or getattr(cfg.channels, "reports", 0))
+        channel = message.guild.get_channel(report_id)
+        if not channel:
+            return
+        embed = discord.Embed(title="🚨 Automatic moderation alert", color=discord.Color.red(), timestamp=datetime.now(timezone.utc))
+        embed.add_field(name="Member", value=f"{message.author.mention}\n`{message.author.id}`", inline=False)
+        embed.add_field(name="Channel", value=message.channel.mention, inline=True)
+        embed.add_field(name="Trigger", value=trigger, inline=True)
+        embed.add_field(name="Action", value=action, inline=False)
+        if message.attachments:
+            embed.set_image(url=message.attachments[0].url)
+        view = discord.ui.View(timeout=None)
+        view.add_item(discord.ui.Button(label="Ban", style=discord.ButtonStyle.danger, custom_id=f"gir:report:ban:{message.author.id}"))
+        view.add_item(discord.ui.Button(label="Dismiss", style=discord.ButtonStyle.secondary, custom_id=f"gir:report:dismiss:{message.author.id}"))
+        await channel.send(embed=embed, view=view)
+
+    @commands.Cog.listener()
+    async def on_interaction(self, interaction: discord.Interaction):
+        custom_id = (interaction.data or {}).get("custom_id", "") if interaction.type == discord.InteractionType.component else ""
+        if not custom_id.startswith("gir:report:"):
+            return
+        if not interaction.user.guild_permissions.ban_members:
+            await interaction.response.send_message("You need permission to ban members to use this.", ephemeral=True); return
+        _, _, action, user_id = custom_id.split(":", 3)
+        if action == "ban":
+            await interaction.guild.ban(discord.Object(id=int(user_id)), reason=f"Reviewed AutoMod report by {interaction.user}")
+            await interaction.response.edit_message(content=f"Banned by {interaction.user.mention}", view=None)
+        else:
+            await interaction.response.edit_message(content=f"Dismissed by {interaction.user.mention}", view=None)
+
+    @commands.Cog.listener()
+    async def on_raw_reaction_add(self, payload: discord.RawReactionActionEvent):
+        if payload.guild_id != cfg.guild_id or payload.member is None or payload.member.bot:
+            return
+        settings = self.settings()
+        for item in settings.get("reactionRoles", []):
+            if item.get("enabled", True) and int(item.get("messageID", 0)) == payload.message_id and str(item.get("emoji")) == str(payload.emoji):
+                role = payload.member.guild.get_role(int(item.get("roleID", 0)))
+                if role:
+                    await payload.member.add_roles(role, reason="GIR reaction role")
+        star = settings["starboard"]
+        if not star.get("enabled") or str(payload.emoji) != str(star.get("emoji", "⭐")):
+            return
+        channel = self.bot.get_channel(payload.channel_id)
+        destination = self.bot.get_channel(int(star.get("channelID") or 0))
+        if not channel or not destination:
+            return
+        try:
+            message = await channel.fetch_message(payload.message_id)
+        except discord.HTTPException:
+            return
+        reaction = next((r for r in message.reactions if str(r.emoji) == str(payload.emoji)), None)
+        if not reaction or reaction.count < int(star.get("threshold", 3)):
+            return
+        embed = discord.Embed(description=message.content or "Shared attachment", color=discord.Color.gold(), timestamp=message.created_at)
+        embed.set_author(name=str(message.author), icon_url=message.author.display_avatar.url)
+        embed.add_field(name="Original", value=f"[Open message]({message.jump_url})")
+        if message.attachments:
+            embed.set_image(url=message.attachments[0].url)
+        existing = self.star_posts.get(message.id)
+        if existing:
+            try:
+                post = await destination.fetch_message(existing); await post.edit(content=f"⭐ **{reaction.count}**", embed=embed); return
+            except discord.HTTPException:
+                pass
+        post = await destination.send(content=f"⭐ **{reaction.count}**", embed=embed)
+        self.star_posts[message.id] = post.id
+
+    @commands.Cog.listener()
+    async def on_raw_reaction_remove(self, payload: discord.RawReactionActionEvent):
+        if payload.guild_id != cfg.guild_id:
+            return
+        for item in self.settings().get("reactionRoles", []):
+            if item.get("enabled", True) and int(item.get("messageID", 0)) == payload.message_id and str(item.get("emoji")) == str(payload.emoji):
+                guild = self.bot.get_guild(payload.guild_id); member = guild.get_member(payload.user_id) if guild else None
+                role = guild.get_role(int(item.get("roleID", 0))) if guild else None
+                if member and role:
+                    await member.remove_roles(role, reason="GIR reaction role removed")
+
+    @app_commands.guilds(cfg.guild_id)
+    @app_commands.command(name="suggest", description="Send an idea to the server suggestion board")
+    async def suggest(self, interaction: discord.Interaction, idea: str):
+        settings = self.settings()["suggestions"]
+        channel = interaction.guild.get_channel(int(settings.get("channelID") or 0)) if settings.get("enabled") else None
+        if not channel:
+            await interaction.response.send_message("Suggestions are not set up yet.", ephemeral=True); return
+        embed = discord.Embed(title="New suggestion", description=idea[:4000], color=discord.Color.teal())
+        embed.set_author(name=interaction.user.display_name, icon_url=interaction.user.display_avatar.url)
+        post = await channel.send(embed=embed); await post.add_reaction("👍"); await post.add_reaction("👎")
+        await interaction.response.send_message("Your suggestion was posted.", ephemeral=True)
+
+    @app_commands.default_permissions(manage_messages=True)
+    @app_commands.guilds(cfg.guild_id)
+    @app_commands.command(name="announce", description="Post a clear announcement in a channel")
+    async def announce(self, interaction: discord.Interaction, channel: discord.TextChannel, title: str, message: str):
+        embed = discord.Embed(title=title[:256], description=message[:4000], color=discord.Color.blurple(), timestamp=datetime.now(timezone.utc))
+        embed.set_footer(text=f"Posted by {interaction.user.display_name}")
+        await channel.send(embed=embed); await interaction.response.send_message("Announcement posted.", ephemeral=True)
+
+    @app_commands.default_permissions(manage_channels=True)
+    @app_commands.guilds(cfg.guild_id)
+    @app_commands.command(name="slowmode", description="Change how often members can send messages")
+    async def slowmode(self, interaction: discord.Interaction, seconds: app_commands.Range[int, 0, 21600]):
+        await interaction.channel.edit(slowmode_delay=seconds, reason=f"Changed by {interaction.user}")
+        await interaction.response.send_message("Slow mode turned off." if seconds == 0 else f"Members can now send one message every {seconds} seconds.", ephemeral=True)
+
+
+async def setup(bot):
+    await bot.add_cog(CommunitySuite(bot))

--- a/cogs/community_suite.py
+++ b/cogs/community_suite.py
@@ -24,7 +24,8 @@ from discord import app_commands
 from discord.ext import commands, tasks
 
 from utils import cfg, logger
-from community_rules import caps_percent, has_invite, recent_count
+from utils.framework.permissions import gatekeeper
+from community_rules import caps_percent, has_invite, is_image_attachment, recent_count
 
 
 DATA_FILE = Path(os.environ.get(
@@ -482,6 +483,17 @@ class CommunitySuite(commands.Cog):
         settings = self.settings()
         lowered = message.content.lower().strip()
 
+        # Prevent image dumps from accounts that have not reached Member+.
+        # This focused safety rule stays active when general AutoMod is off.
+        image_attachments = [attachment for attachment in message.attachments
+                             if is_image_attachment(attachment.content_type, attachment.filename)]
+        if len(image_attachments) >= 4 and not gatekeeper.has(message.guild, message.author, 1):
+            image_rule = dict(settings["automod"])
+            image_rule.update({"deleteMessage": True, "timeoutHours": 168})
+            await self._moderate(message, image_rule,
+                                 f"{len(image_attachments)} images in one message from a user below Member+")
+            return
+
         if message.author.id in self.afk:
             self.afk.pop(message.author.id, None)
             try:
@@ -529,8 +541,8 @@ class CommunitySuite(commands.Cog):
         now = time.monotonic()
         key = (message.guild.id, message.author.id)
         self.activity[key].append(now)
-        if message.attachments and any(a.content_type and a.content_type.startswith("image/") for a in message.attachments):
-            self.images[key].extend([now] * len(message.attachments))
+        if image_attachments:
+            self.images[key].extend([now] * len(image_attachments))
         findings = []
         window = int(auto.get("imageWindowSeconds", 20))
         image_count = recent_count(self.images[key], now, window)
@@ -564,8 +576,10 @@ class CommunitySuite(commands.Cog):
                 action = f"Timed out for {hours} hours"
             except discord.HTTPException:
                 action = "Message removed; timeout could not be applied"
-        report_id = int(settings.get("reportChannelID") or getattr(cfg.channels, "reports", 0))
-        channel = message.guild.get_channel(report_id)
+        report_id = int(settings.get("reportChannelID") or 0)
+        channel = message.guild.get_channel(report_id) if report_id else None
+        channel = channel or discord.utils.get(message.guild.text_channels, name="reports")
+        channel = channel or message.guild.get_channel(int(getattr(cfg.channels, "reports", 0) or 0))
         if not channel:
             return
         embed = discord.Embed(title="🚨 Automatic moderation alert", color=discord.Color.red(), timestamp=datetime.now(timezone.utc))
@@ -585,13 +599,18 @@ class CommunitySuite(commands.Cog):
         custom_id = (interaction.data or {}).get("custom_id", "") if interaction.type == discord.InteractionType.component else ""
         if not custom_id.startswith("gir:report:"):
             return
-        if not interaction.user.guild_permissions.ban_members:
-            await interaction.response.send_message("You need permission to ban members to use this.", ephemeral=True); return
         _, _, action, user_id = custom_id.split(":", 3)
         if action == "ban":
-            await interaction.guild.ban(discord.Object(id=int(user_id)), reason=f"Reviewed AutoMod report by {interaction.user}")
-            await interaction.response.edit_message(content=f"Banned by {interaction.user.mention}", view=None)
+            if not interaction.user.guild_permissions.ban_members:
+                await interaction.response.send_message("You need permission to ban members to use this.", ephemeral=True); return
+            try:
+                await interaction.guild.ban(discord.Object(id=int(user_id)), reason=f"Reviewed AutoMod report by {interaction.user}")
+                await interaction.response.edit_message(content=f"Banned by {interaction.user.mention}", view=None)
+            except discord.Forbidden:
+                await interaction.response.send_message("Discord would not allow that ban. Check GIR's Ban Members permission and role position.", ephemeral=True)
         else:
+            if not interaction.user.guild_permissions.manage_messages:
+                await interaction.response.send_message("You need permission to manage messages to dismiss reports.", ephemeral=True); return
             await interaction.response.edit_message(content=f"Dismissed by {interaction.user.mention}", view=None)
 
     @commands.Cog.listener()

--- a/cogs/community_suite.py
+++ b/cogs/community_suite.py
@@ -32,10 +32,10 @@ from community_rules import (caps_percent, detect_scam, has_hidden_invite, has_i
                              normalize_obfuscated_text, recent_count)
 
 
-DATA_FILE = Path(os.environ.get(
-    "GIR_COMMUNITY_FILE",
-    str(Path.home() / "Library/Application Support/SowensServer/GIRRuntime/dashboard/data/community.json"),
-))
+from utils.runtime_paths import runtime_data_file
+
+
+DATA_FILE = Path(os.environ.get("GIR_COMMUNITY_FILE", runtime_data_file("community.json")))
 GAME_STATE_FILE = DATA_FILE.with_name("free-games-state.json")
 GAME_STATUS_FILE = DATA_FILE.with_name("free-games-status.json")
 GAME_REQUEST_FILE = DATA_FILE.with_name("free-games-request.json")
@@ -64,7 +64,7 @@ DEFAULTS = {
                         "storeDisplayNames": True, "storeAvatarHashes": True, "storeRoles": True},
     "welcome": {"enabled": False, "channelID": 0, "message": "Welcome {mention} to {server}!", "goodbyeEnabled": False, "goodbyeMessage": "{name} left the server."},
     "autorole": {"enabled": False, "roleIDs": []},
-    "starboard": {"enabled": False, "channelID": 0, "threshold": 3, "emoji": "⭐"},
+    "starboard": {"enabled": False, "channelID": 0, "threshold": 5, "emoji": "⭐"},
     "suggestions": {"enabled": False, "channelID": 0},
     "freeGames": {"enabled": False, "channelID": 0, "platforms": ["pc", "steam", "epic-games-store", "ps4", "ps5", "xbox-one", "xbox-series-xs"], "types": ["game"], "sources": ["gamerpower", "epic", "cheapshark"], "offerMode": "both", "minimumDiscountPercent": 50, "checkMinutes": 15, "pingRoleID": 0, "minimumWorth": 0, "hideUnrated": False, "includeExpired": False, "maxPostsPerCheck": 5},
     "movieNight": {"enabled": False, "channelID": 0, "pingRoleID": 0},
@@ -841,7 +841,7 @@ class CommunitySuite(commands.Cog):
         except discord.HTTPException:
             return
         reaction = next((r for r in message.reactions if str(r.emoji) == str(payload.emoji)), None)
-        if not reaction or reaction.count < int(star.get("threshold", 3)):
+        if not reaction or reaction.count < int(star.get("threshold", 5)):
             return
         embed = discord.Embed(description=message.content or "Shared attachment", color=discord.Color.gold(), timestamp=message.created_at)
         embed.set_author(name=str(message.author), icon_url=message.author.display_avatar.url)

--- a/cogs/monitors/mod/filter.py
+++ b/cogs/monitors/mod/filter.py
@@ -13,6 +13,7 @@ from utils.framework import gatekeeper, find_triggered_filters
 from utils.framework.filter import has_only_silent_filtered_words
 from utils.mod import mute
 from utils.views import manual_report, report
+from community_rules import normalize_obfuscated_text
 
 
 class Filter(commands.Cog):
@@ -158,7 +159,7 @@ class Filter(commands.Cog):
         return triggered
 
     async def do_invite_filter(self, message):
-        invites = re.findall(self.invite_filter, message.content, flags=re.S)
+        invites = re.findall(self.invite_filter, normalize_obfuscated_text(message.content), flags=re.S)
         if not invites:
             return
 

--- a/cogs/monitors/utils/jailbreak_monitors.py
+++ b/cogs/monitors/utils/jailbreak_monitors.py
@@ -106,7 +106,7 @@ class Sileo(commands.Cog):
             return
 
         urlscheme = re.search(
-            "(sileo|zbra):\/\/package\/([a-zA-Z0-9]+(\.[a-zA-Z0-9]+)+(\.[a-zA-Z0-9]+)+)", message.content)
+                r"(sileo|zbra)://package/([a-zA-Z0-9]+(\.[a-zA-Z0-9]+)+(\.[a-zA-Z0-9]+)+)", message.content)
 
         if urlscheme is None:
             return

--- a/cogs/music_suite.py
+++ b/cogs/music_suite.py
@@ -1,0 +1,346 @@
+"""Music discovery, universal links, and Last.fm activity commands."""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import re
+import tempfile
+from pathlib import Path
+from urllib.parse import quote
+
+import aiohttp
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+from utils import cfg, logger
+
+
+SONG_LINK_API = "https://api.song.link/v1-alpha.1/links"
+ITUNES_SEARCH_API = "https://itunes.apple.com/search"
+LASTFM_API = "https://ws.audioscrobbler.com/2.0/"
+COMMUNITY_FILE = Path(os.environ.get(
+    "GIR_COMMUNITY_FILE",
+    str(Path.home() / "Library/Application Support/SowensServer/GIRRuntime/dashboard/data/community.json"),
+))
+MUSIC_USERS_FILE = COMMUNITY_FILE.with_name("music-users.json")
+SUPPORTED_LINK = re.compile(
+    r"https?://(?:open\.spotify\.com|spotify\.link|music\.apple\.com|youtu\.be|(?:www\.)?youtube\.com|tidal\.com|deezer\.com|soundcloud\.com)/\S+",
+    re.IGNORECASE,
+)
+PLATFORMS = (
+    ("spotify", "Spotify"), ("appleMusic", "Apple Music"), ("youtube", "YouTube"),
+    ("youtubeMusic", "YouTube Music"), ("tidal", "TIDAL"), ("deezer", "Deezer"),
+    ("amazonMusic", "Amazon Music"), ("soundcloud", "SoundCloud"),
+)
+PERIODS = {
+    "week": "7day", "month": "1month", "three-months": "3month",
+    "six-months": "6month", "year": "12month", "all-time": "overall",
+}
+
+
+def _read_json(path: Path, fallback):
+    try:
+        return json.loads(path.read_text())
+    except (OSError, ValueError, TypeError):
+        return fallback
+
+
+def _write_json(path: Path, value) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, name = tempfile.mkstemp(prefix=path.name, dir=path.parent)
+    try:
+        with os.fdopen(fd, "w") as handle:
+            json.dump(value, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+        os.chmod(name, 0o600)
+        os.replace(name, path)
+    finally:
+        if os.path.exists(name):
+            os.unlink(name)
+
+
+def _music_settings() -> dict:
+    defaults = {
+        "enabled": True, "autoConvertLinks": True, "allowDotFm": True,
+        "monitoredChannelIDs": [], "lastfmEnabled": True,
+    }
+    current = _read_json(COMMUNITY_FILE, {}).get("music", {})
+    defaults.update(current if isinstance(current, dict) else {})
+    return defaults
+
+
+def _clean(value: object, limit: int = 250) -> str:
+    return discord.utils.escape_markdown(str(value or "Unknown")[:limit])
+
+
+def _number(value: object) -> str:
+    try:
+        return f"{int(value or 0):,}"
+    except (TypeError, ValueError):
+        return "0"
+
+
+class MusicSuite(commands.Cog):
+    music = app_commands.Group(
+        name="music", description="Find songs and open them in your preferred music service",
+        guild_ids=[cfg.guild_id],
+    )
+    fm = app_commands.Group(
+        name="fm", description="View Last.fm listening activity and profiles",
+        guild_ids=[cfg.guild_id],
+    )
+
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+        self._session: aiohttp.ClientSession | None = None
+        self._cooldown = commands.CooldownMapping.from_cooldown(4, 30.0, commands.BucketType.user)
+
+    async def cog_load(self):
+        self._session = aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=12), headers={"User-Agent": "GIR-Music/1.0"})
+
+    async def cog_unload(self):
+        if self._session:
+            await self._session.close()
+
+    async def _json(self, url: str, *, params: dict | None = None) -> dict:
+        assert self._session is not None
+        async with self._session.get(url, params=params) as response:
+            if response.status == 429:
+                raise RuntimeError("The music service is busy. Try again in a moment.")
+            response.raise_for_status()
+            return await response.json(content_type=None)
+
+    async def _song_links(self, url: str) -> dict:
+        if not _music_settings().get("enabled", True):
+            raise RuntimeError("Music tools are turned off for this server.")
+        return await self._json(SONG_LINK_API, params={"url": url})
+
+    async def _search_song(self, query: str) -> str | None:
+        data = await self._json(ITUNES_SEARCH_API, params={"term": query, "entity": "song", "limit": "1"})
+        rows = data.get("results") or []
+        return rows[0].get("trackViewUrl") if rows else None
+
+    @staticmethod
+    def _song_embed(data: dict) -> tuple[discord.Embed, discord.ui.View]:
+        entities = data.get("entitiesByUniqueId") or {}
+        entity = entities.get(data.get("entityUniqueId")) or next(iter(entities.values()), {})
+        title = _clean(entity.get("title"), 180)
+        artist = _clean(entity.get("artistName"), 180)
+        embed = discord.Embed(title=title, description=f"by **{artist}**", color=0x79D956)
+        thumbnail = entity.get("thumbnailUrl")
+        if thumbnail and str(thumbnail).startswith("https://"):
+            embed.set_thumbnail(url=thumbnail)
+        embed.set_footer(text="Choose a service to listen")
+        view = discord.ui.View(timeout=180)
+        links = data.get("linksByPlatform") or {}
+        for index, (key, label) in enumerate(PLATFORMS):
+            url = (links.get(key) or {}).get("url")
+            if url:
+                view.add_item(discord.ui.Button(
+                    label=label, url=url, style=discord.ButtonStyle.link, row=index // 5))
+        return embed, view
+
+    async def _send_song(self, destination, url: str, *, ephemeral: bool = False):
+        try:
+            data = await self._song_links(url)
+            embed, view = self._song_embed(data)
+        except (aiohttp.ClientError, asyncio.TimeoutError, RuntimeError, ValueError) as error:
+            logger.warning("Music link lookup failed: %s", error)
+            if isinstance(destination, discord.Interaction):
+                await destination.followup.send("I could not match that song across services right now.", ephemeral=True)
+            return
+        if isinstance(destination, discord.Interaction):
+            await destination.followup.send(embed=embed, view=view, ephemeral=ephemeral)
+        else:
+            await destination.reply(embed=embed, view=view, mention_author=False)
+
+    @music.command(name="link", description="Turn a song link into buttons for other music services")
+    async def music_link(self, interaction: discord.Interaction, url: str):
+        if not SUPPORTED_LINK.search(url):
+            await interaction.response.send_message("Paste a Spotify, Apple Music, YouTube, TIDAL, Deezer, or SoundCloud song link.", ephemeral=True)
+            return
+        await interaction.response.defer()
+        await self._send_song(interaction, url)
+
+    @music.command(name="search", description="Find a song and get links for popular music services")
+    async def music_search(self, interaction: discord.Interaction, query: str):
+        await interaction.response.defer()
+        if not _music_settings().get("enabled", True):
+            await interaction.followup.send("Music tools are turned off for this server.", ephemeral=True)
+            return
+        try:
+            url = await self._search_song(query[:200])
+        except (aiohttp.ClientError, asyncio.TimeoutError, RuntimeError, ValueError):
+            url = None
+        if not url:
+            await interaction.followup.send("I could not find a song for that search.", ephemeral=True)
+            return
+        await self._send_song(interaction, url)
+
+    def _lastfm_username(self, discord_id: int, supplied: str | None = None) -> str | None:
+        if supplied:
+            return supplied.strip()[:64]
+        return _read_json(MUSIC_USERS_FILE, {}).get(str(discord_id))
+
+    async def _lastfm(self, method: str, **params) -> dict:
+        settings = _music_settings()
+        if not settings.get("enabled", True) or not settings.get("lastfmEnabled", True):
+            raise RuntimeError("Last.fm commands are turned off for this server.")
+        api_key = getattr(cfg, "lastfm_api_key", None)
+        if not api_key:
+            raise RuntimeError("Last.fm needs its free API key added by the bot owner.")
+        payload = {"method": method, "api_key": api_key, "format": "json", **params}
+        data = await self._json(LASTFM_API, params=payload)
+        if data.get("error"):
+            raise RuntimeError(str(data.get("message") or "Last.fm rejected that request."))
+        return data
+
+    async def _fm_error(self, interaction: discord.Interaction, error: Exception):
+        message = str(error) if isinstance(error, RuntimeError) else "Last.fm did not answer in time."
+        await interaction.followup.send(message[:500], ephemeral=True)
+
+    @fm.command(name="set", description="Connect your Discord profile to a Last.fm username")
+    async def fm_set(self, interaction: discord.Interaction, username: str):
+        await interaction.response.defer(ephemeral=True)
+        username = username.strip()[:64]
+        try:
+            data = await self._lastfm("user.getInfo", user=username)
+        except Exception as error:
+            await self._fm_error(interaction, error); return
+        users = _read_json(MUSIC_USERS_FILE, {})
+        users[str(interaction.user.id)] = str(data["user"]["name"])
+        _write_json(MUSIC_USERS_FILE, users)
+        await interaction.followup.send(f"Connected your profile to **{_clean(data['user']['name'])}**.", ephemeral=True)
+
+    @fm.command(name="remove", description="Remove your saved Last.fm username")
+    async def fm_remove(self, interaction: discord.Interaction):
+        users = _read_json(MUSIC_USERS_FILE, {})
+        users.pop(str(interaction.user.id), None)
+        _write_json(MUSIC_USERS_FILE, users)
+        await interaction.response.send_message("Removed your saved Last.fm username.", ephemeral=True)
+
+    @fm.command(name="now", description="Show your latest or currently playing Last.fm track")
+    async def fm_now(self, interaction: discord.Interaction, username: str | None = None):
+        await interaction.response.defer()
+        user = self._lastfm_username(interaction.user.id, username)
+        if not user:
+            await interaction.followup.send("Use `/fm set` first, or provide a Last.fm username.", ephemeral=True); return
+        try:
+            data = await self._lastfm("user.getRecentTracks", user=user, limit=1, extended=1)
+            tracks = (data.get("recenttracks") or {}).get("track") or []
+            if not tracks:
+                raise RuntimeError("That profile has no recent tracks.")
+            track = tracks[0]
+        except Exception as error:
+            await self._fm_error(interaction, error); return
+        artist = track.get("artist") or {}
+        artist_name = artist.get("name") if isinstance(artist, dict) else artist
+        now = (track.get("@attr") or {}).get("nowplaying") == "true"
+        embed = discord.Embed(title=_clean(track.get("name"), 180), description=f"by **{_clean(artist_name)}**", color=0xD92323)
+        embed.set_author(name=f"{user} · {'Now playing' if now else 'Last played'}", url=f"https://www.last.fm/user/{quote(user)}")
+        album = track.get("album") or {}
+        if isinstance(album, dict) and album.get("#text"):
+            embed.add_field(name="Album", value=_clean(album["#text"]), inline=True)
+        images = track.get("image") or []
+        image = next((item.get("#text") for item in reversed(images) if item.get("#text")), None)
+        if image:
+            embed.set_thumbnail(url=image)
+        view = discord.ui.View(timeout=180)
+        if track.get("url"):
+            view.add_item(discord.ui.Button(label="Last.fm", url=track["url"], style=discord.ButtonStyle.link))
+        await interaction.followup.send(embed=embed, view=view)
+
+    @fm.command(name="recent", description="Show recent tracks from a Last.fm profile")
+    async def fm_recent(self, interaction: discord.Interaction, username: str | None = None):
+        await interaction.response.defer()
+        user = self._lastfm_username(interaction.user.id, username)
+        if not user:
+            await interaction.followup.send("Use `/fm set` first, or provide a Last.fm username.", ephemeral=True); return
+        try:
+            data = await self._lastfm("user.getRecentTracks", user=user, limit=8)
+            tracks = (data.get("recenttracks") or {}).get("track") or []
+        except Exception as error:
+            await self._fm_error(interaction, error); return
+        lines = []
+        for track in tracks[:8]:
+            artist = track.get("artist") or {}
+            artist_name = artist.get("#text") if isinstance(artist, dict) else artist
+            lines.append(f"**{_clean(track.get('name'), 100)}** — {_clean(artist_name, 100)}")
+        embed = discord.Embed(title=f"{_clean(user)} · recent tracks", description="\n".join(lines) or "No recent tracks.", color=0xD92323)
+        await interaction.followup.send(embed=embed)
+
+    @fm.command(name="top", description="Show top Last.fm artists for a time period")
+    @app_commands.choices(period=[app_commands.Choice(name=name.replace("-", " ").title(), value=value) for name, value in PERIODS.items()])
+    async def fm_top(self, interaction: discord.Interaction, period: app_commands.Choice[str], username: str | None = None):
+        await interaction.response.defer()
+        user = self._lastfm_username(interaction.user.id, username)
+        if not user:
+            await interaction.followup.send("Use `/fm set` first, or provide a Last.fm username.", ephemeral=True); return
+        try:
+            data = await self._lastfm("user.getTopArtists", user=user, period=period.value, limit=10)
+            artists = (data.get("topartists") or {}).get("artist") or []
+        except Exception as error:
+            await self._fm_error(interaction, error); return
+        lines = [f"`{index:>2}` **{_clean(item.get('name'), 100)}** · {_number(item.get('playcount'))} plays" for index, item in enumerate(artists[:10], 1)]
+        embed = discord.Embed(title=f"{_clean(user)} · top artists", description="\n".join(lines) or "No listening history for that period.", color=0xD92323)
+        embed.set_footer(text=period.name)
+        await interaction.followup.send(embed=embed)
+
+    @fm.command(name="profile", description="Show a Last.fm profile summary")
+    async def fm_profile(self, interaction: discord.Interaction, username: str | None = None):
+        await interaction.response.defer()
+        user = self._lastfm_username(interaction.user.id, username)
+        if not user:
+            await interaction.followup.send("Use `/fm set` first, or provide a Last.fm username.", ephemeral=True); return
+        try:
+            profile = (await self._lastfm("user.getInfo", user=user))["user"]
+        except Exception as error:
+            await self._fm_error(interaction, error); return
+        embed = discord.Embed(title=_clean(profile.get("realname") or profile.get("name")), url=profile.get("url"), color=0xD92323)
+        embed.add_field(name="Scrobbles", value=_number(profile.get("playcount")))
+        embed.add_field(name="Artists", value=_number(profile.get("artist_count")))
+        embed.add_field(name="Tracks", value=_number(profile.get("track_count")))
+        await interaction.followup.send(embed=embed)
+
+    @commands.Cog.listener()
+    async def on_message(self, message: discord.Message):
+        settings = _music_settings()
+        if not settings.get("enabled", True) or not message.guild or message.author.bot or message.guild.id != cfg.guild_id:
+            return
+        channels = {int(item) for item in settings.get("monitoredChannelIDs", []) if str(item).isdigit()}
+        if channels and message.channel.id not in channels:
+            return
+        bucket = self._cooldown.get_bucket(message)
+        if bucket.update_rate_limit(message.created_at.timestamp()):
+            return
+        content = message.content.strip()
+        if settings.get("allowDotFm", True) and re.fullmatch(r"\.fm(?:\s+([A-Za-z0-9_-]{1,64}))?", content, re.IGNORECASE):
+            username = (re.fullmatch(r"\.fm(?:\s+([A-Za-z0-9_-]{1,64}))?", content, re.IGNORECASE).group(1)
+                        or self._lastfm_username(message.author.id))
+            if not username or not getattr(cfg, "lastfm_api_key", None):
+                await message.reply("Use `/fm set` first. The server owner must also add a free Last.fm API key.", mention_author=False)
+                return
+            try:
+                data = await self._lastfm("user.getRecentTracks", user=username, limit=1)
+                track = ((data.get("recenttracks") or {}).get("track") or [])[0]
+                artist = track.get("artist") or {}
+                artist_name = artist.get("#text") if isinstance(artist, dict) else artist
+                track_url = track.get("url")
+                suffix = f"\n<{track_url}>" if track_url else ""
+                await message.reply(
+                    f"🎵 **{_clean(track.get('name'))}** — {_clean(artist_name)}{suffix}",
+                    mention_author=False,
+                )
+            except (aiohttp.ClientError, asyncio.TimeoutError, RuntimeError, IndexError, ValueError):
+                await message.reply("I could not load that Last.fm activity right now.", mention_author=False)
+            return
+        match = SUPPORTED_LINK.search(content)
+        if match and settings.get("autoConvertLinks", True):
+            await self._send_song(message, match.group(0))
+
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(MusicSuite(bot))

--- a/cogs/music_suite.py
+++ b/cogs/music_suite.py
@@ -1,13 +1,11 @@
-"""Music discovery, universal links, and Last.fm activity commands."""
+"""Music discovery and cross-service link commands."""
 from __future__ import annotations
 
 import asyncio
 import json
 import os
 import re
-import tempfile
 from pathlib import Path
-from urllib.parse import quote
 
 import aiohttp
 import discord
@@ -15,16 +13,12 @@ from discord import app_commands
 from discord.ext import commands
 
 from utils import cfg, logger
+from utils.runtime_paths import runtime_data_file
 
 
 SONG_LINK_API = "https://api.song.link/v1-alpha.1/links"
 ITUNES_SEARCH_API = "https://itunes.apple.com/search"
-LASTFM_API = "https://ws.audioscrobbler.com/2.0/"
-COMMUNITY_FILE = Path(os.environ.get(
-    "GIR_COMMUNITY_FILE",
-    str(Path.home() / "Library/Application Support/SowensServer/GIRRuntime/dashboard/data/community.json"),
-))
-MUSIC_USERS_FILE = COMMUNITY_FILE.with_name("music-users.json")
+COMMUNITY_FILE = Path(os.environ.get("GIR_COMMUNITY_FILE", runtime_data_file("community.json")))
 SUPPORTED_LINK = re.compile(
     r"https?://(?:open\.spotify\.com|spotify\.link|music\.apple\.com|youtu\.be|(?:www\.)?youtube\.com|tidal\.com|deezer\.com|soundcloud\.com)/\S+",
     re.IGNORECASE,
@@ -34,11 +28,6 @@ PLATFORMS = (
     ("youtubeMusic", "YouTube Music"), ("tidal", "TIDAL"), ("deezer", "Deezer"),
     ("amazonMusic", "Amazon Music"), ("soundcloud", "SoundCloud"),
 )
-PERIODS = {
-    "week": "7day", "month": "1month", "three-months": "3month",
-    "six-months": "6month", "year": "12month", "all-time": "overall",
-}
-
 
 def _read_json(path: Path, fallback):
     try:
@@ -47,24 +36,9 @@ def _read_json(path: Path, fallback):
         return fallback
 
 
-def _write_json(path: Path, value) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    fd, name = tempfile.mkstemp(prefix=path.name, dir=path.parent)
-    try:
-        with os.fdopen(fd, "w") as handle:
-            json.dump(value, handle, indent=2, sort_keys=True)
-            handle.write("\n")
-        os.chmod(name, 0o600)
-        os.replace(name, path)
-    finally:
-        if os.path.exists(name):
-            os.unlink(name)
-
-
 def _music_settings() -> dict:
     defaults = {
-        "enabled": True, "autoConvertLinks": True, "allowDotFm": True,
-        "monitoredChannelIDs": [], "lastfmEnabled": True,
+        "enabled": True, "autoConvertLinks": True, "monitoredChannelIDs": [],
     }
     current = _read_json(COMMUNITY_FILE, {}).get("music", {})
     defaults.update(current if isinstance(current, dict) else {})
@@ -75,20 +49,9 @@ def _clean(value: object, limit: int = 250) -> str:
     return discord.utils.escape_markdown(str(value or "Unknown")[:limit])
 
 
-def _number(value: object) -> str:
-    try:
-        return f"{int(value or 0):,}"
-    except (TypeError, ValueError):
-        return "0"
-
-
 class MusicSuite(commands.Cog):
     music = app_commands.Group(
         name="music", description="Find songs and open them in your preferred music service",
-        guild_ids=[cfg.guild_id],
-    )
-    fm = app_commands.Group(
-        name="fm", description="View Last.fm listening activity and profiles",
         guild_ids=[cfg.guild_id],
     )
 
@@ -180,131 +143,6 @@ class MusicSuite(commands.Cog):
             return
         await self._send_song(interaction, url)
 
-    def _lastfm_username(self, discord_id: int, supplied: str | None = None) -> str | None:
-        if supplied:
-            return supplied.strip()[:64]
-        return _read_json(MUSIC_USERS_FILE, {}).get(str(discord_id))
-
-    async def _lastfm(self, method: str, **params) -> dict:
-        settings = _music_settings()
-        if not settings.get("enabled", True) or not settings.get("lastfmEnabled", True):
-            raise RuntimeError("Last.fm commands are turned off for this server.")
-        api_key = getattr(cfg, "lastfm_api_key", None)
-        if not api_key:
-            raise RuntimeError("Last.fm needs its free API key added by the bot owner.")
-        payload = {"method": method, "api_key": api_key, "format": "json", **params}
-        data = await self._json(LASTFM_API, params=payload)
-        if data.get("error"):
-            raise RuntimeError(str(data.get("message") or "Last.fm rejected that request."))
-        return data
-
-    async def _fm_error(self, interaction: discord.Interaction, error: Exception):
-        message = str(error) if isinstance(error, RuntimeError) else "Last.fm did not answer in time."
-        await interaction.followup.send(message[:500], ephemeral=True)
-
-    @fm.command(name="set", description="Connect your Discord profile to a Last.fm username")
-    async def fm_set(self, interaction: discord.Interaction, username: str):
-        await interaction.response.defer(ephemeral=True)
-        username = username.strip()[:64]
-        try:
-            data = await self._lastfm("user.getInfo", user=username)
-        except Exception as error:
-            await self._fm_error(interaction, error); return
-        users = _read_json(MUSIC_USERS_FILE, {})
-        users[str(interaction.user.id)] = str(data["user"]["name"])
-        _write_json(MUSIC_USERS_FILE, users)
-        await interaction.followup.send(f"Connected your profile to **{_clean(data['user']['name'])}**.", ephemeral=True)
-
-    @fm.command(name="remove", description="Remove your saved Last.fm username")
-    async def fm_remove(self, interaction: discord.Interaction):
-        users = _read_json(MUSIC_USERS_FILE, {})
-        users.pop(str(interaction.user.id), None)
-        _write_json(MUSIC_USERS_FILE, users)
-        await interaction.response.send_message("Removed your saved Last.fm username.", ephemeral=True)
-
-    @fm.command(name="now", description="Show your latest or currently playing Last.fm track")
-    async def fm_now(self, interaction: discord.Interaction, username: str | None = None):
-        await interaction.response.defer()
-        user = self._lastfm_username(interaction.user.id, username)
-        if not user:
-            await interaction.followup.send("Use `/fm set` first, or provide a Last.fm username.", ephemeral=True); return
-        try:
-            data = await self._lastfm("user.getRecentTracks", user=user, limit=1, extended=1)
-            tracks = (data.get("recenttracks") or {}).get("track") or []
-            if not tracks:
-                raise RuntimeError("That profile has no recent tracks.")
-            track = tracks[0]
-        except Exception as error:
-            await self._fm_error(interaction, error); return
-        artist = track.get("artist") or {}
-        artist_name = artist.get("name") if isinstance(artist, dict) else artist
-        now = (track.get("@attr") or {}).get("nowplaying") == "true"
-        embed = discord.Embed(title=_clean(track.get("name"), 180), description=f"by **{_clean(artist_name)}**", color=0xD92323)
-        embed.set_author(name=f"{user} · {'Now playing' if now else 'Last played'}", url=f"https://www.last.fm/user/{quote(user)}")
-        album = track.get("album") or {}
-        if isinstance(album, dict) and album.get("#text"):
-            embed.add_field(name="Album", value=_clean(album["#text"]), inline=True)
-        images = track.get("image") or []
-        image = next((item.get("#text") for item in reversed(images) if item.get("#text")), None)
-        if image:
-            embed.set_thumbnail(url=image)
-        view = discord.ui.View(timeout=180)
-        if track.get("url"):
-            view.add_item(discord.ui.Button(label="Last.fm", url=track["url"], style=discord.ButtonStyle.link))
-        await interaction.followup.send(embed=embed, view=view)
-
-    @fm.command(name="recent", description="Show recent tracks from a Last.fm profile")
-    async def fm_recent(self, interaction: discord.Interaction, username: str | None = None):
-        await interaction.response.defer()
-        user = self._lastfm_username(interaction.user.id, username)
-        if not user:
-            await interaction.followup.send("Use `/fm set` first, or provide a Last.fm username.", ephemeral=True); return
-        try:
-            data = await self._lastfm("user.getRecentTracks", user=user, limit=8)
-            tracks = (data.get("recenttracks") or {}).get("track") or []
-        except Exception as error:
-            await self._fm_error(interaction, error); return
-        lines = []
-        for track in tracks[:8]:
-            artist = track.get("artist") or {}
-            artist_name = artist.get("#text") if isinstance(artist, dict) else artist
-            lines.append(f"**{_clean(track.get('name'), 100)}** — {_clean(artist_name, 100)}")
-        embed = discord.Embed(title=f"{_clean(user)} · recent tracks", description="\n".join(lines) or "No recent tracks.", color=0xD92323)
-        await interaction.followup.send(embed=embed)
-
-    @fm.command(name="top", description="Show top Last.fm artists for a time period")
-    @app_commands.choices(period=[app_commands.Choice(name=name.replace("-", " ").title(), value=value) for name, value in PERIODS.items()])
-    async def fm_top(self, interaction: discord.Interaction, period: app_commands.Choice[str], username: str | None = None):
-        await interaction.response.defer()
-        user = self._lastfm_username(interaction.user.id, username)
-        if not user:
-            await interaction.followup.send("Use `/fm set` first, or provide a Last.fm username.", ephemeral=True); return
-        try:
-            data = await self._lastfm("user.getTopArtists", user=user, period=period.value, limit=10)
-            artists = (data.get("topartists") or {}).get("artist") or []
-        except Exception as error:
-            await self._fm_error(interaction, error); return
-        lines = [f"`{index:>2}` **{_clean(item.get('name'), 100)}** · {_number(item.get('playcount'))} plays" for index, item in enumerate(artists[:10], 1)]
-        embed = discord.Embed(title=f"{_clean(user)} · top artists", description="\n".join(lines) or "No listening history for that period.", color=0xD92323)
-        embed.set_footer(text=period.name)
-        await interaction.followup.send(embed=embed)
-
-    @fm.command(name="profile", description="Show a Last.fm profile summary")
-    async def fm_profile(self, interaction: discord.Interaction, username: str | None = None):
-        await interaction.response.defer()
-        user = self._lastfm_username(interaction.user.id, username)
-        if not user:
-            await interaction.followup.send("Use `/fm set` first, or provide a Last.fm username.", ephemeral=True); return
-        try:
-            profile = (await self._lastfm("user.getInfo", user=user))["user"]
-        except Exception as error:
-            await self._fm_error(interaction, error); return
-        embed = discord.Embed(title=_clean(profile.get("realname") or profile.get("name")), url=profile.get("url"), color=0xD92323)
-        embed.add_field(name="Scrobbles", value=_number(profile.get("playcount")))
-        embed.add_field(name="Artists", value=_number(profile.get("artist_count")))
-        embed.add_field(name="Tracks", value=_number(profile.get("track_count")))
-        await interaction.followup.send(embed=embed)
-
     @commands.Cog.listener()
     async def on_message(self, message: discord.Message):
         settings = _music_settings()
@@ -317,26 +155,6 @@ class MusicSuite(commands.Cog):
         if bucket.update_rate_limit(message.created_at.timestamp()):
             return
         content = message.content.strip()
-        if settings.get("allowDotFm", True) and re.fullmatch(r"\.fm(?:\s+([A-Za-z0-9_-]{1,64}))?", content, re.IGNORECASE):
-            username = (re.fullmatch(r"\.fm(?:\s+([A-Za-z0-9_-]{1,64}))?", content, re.IGNORECASE).group(1)
-                        or self._lastfm_username(message.author.id))
-            if not username or not getattr(cfg, "lastfm_api_key", None):
-                await message.reply("Use `/fm set` first. The server owner must also add a free Last.fm API key.", mention_author=False)
-                return
-            try:
-                data = await self._lastfm("user.getRecentTracks", user=username, limit=1)
-                track = ((data.get("recenttracks") or {}).get("track") or [])[0]
-                artist = track.get("artist") or {}
-                artist_name = artist.get("#text") if isinstance(artist, dict) else artist
-                track_url = track.get("url")
-                suffix = f"\n<{track_url}>" if track_url else ""
-                await message.reply(
-                    f"🎵 **{_clean(track.get('name'))}** — {_clean(artist_name)}{suffix}",
-                    mention_author=False,
-                )
-            except (aiohttp.ClientError, asyncio.TimeoutError, RuntimeError, IndexError, ValueError):
-                await message.reply("I could not load that Last.fm activity right now.", mention_author=False)
-            return
         match = SUPPORTED_LINK.search(content)
         if match and settings.get("autoConvertLinks", True):
             await self._send_song(message, match.group(0))

--- a/cogs/server_suite.py
+++ b/cogs/server_suite.py
@@ -160,12 +160,33 @@ class ServerSuite(commands.Cog):
             async with session.get(url, timeout=25) as response:
                 response.raise_for_status(); return await response.json()
 
+    async def _get_devices(self):
+        now = asyncio.get_running_loop().time()
+        if self._devices and now - self._device_cache_time < 3600:
+            return self._devices
+        self._devices = await self._get_json(IPSW_API + "/devices")
+        self._device_cache_time = now
+        return self._devices
+
+    @staticmethod
+    def _normalise_device_name(value: str):
+        value = value.casefold().replace("‑", "-")
+        value = re.sub(r"\b(1st|2nd|3rd|([4-9]|\d{2,})th)\s+(generation|gen)\b", r"\1", value)
+        value = re.sub(r"\b(first|second|third|fourth|fifth|sixth|seventh|eighth|ninth|tenth)\s+(generation|gen)\b", r"\1", value)
+        number_words = {"first": "1", "second": "2", "third": "3", "fourth": "4", "fifth": "5",
+                        "sixth": "6", "seventh": "7", "eighth": "8", "ninth": "9", "tenth": "10"}
+        for word, number in number_words.items():
+            value = re.sub(rf"\b{word}\b", number, value)
+        value = re.sub(r"(\d+)(st|nd|rd|th)\b", r"\1", value)
+        return re.sub(r"[^a-z0-9]+", " ", value).strip()
+
     async def _find_device(self, device_text: str):
-        devices = await self._get_json(IPSW_API + "/devices")
-        names = {str(item["name"]).lower(): item for item in devices}
-        identifiers = {str(item["identifier"]).lower(): item for item in devices}
-        needle = device_text.strip().lower()
-        device = names.get(needle) or identifiers.get(needle)
+        devices = await self._get_devices()
+        names = {self._normalise_device_name(str(item["name"])): item for item in devices}
+        identifiers = {str(item["identifier"]).casefold(): item for item in devices}
+        raw = device_text.strip().casefold()
+        needle = self._normalise_device_name(device_text)
+        device = names.get(needle) or identifiers.get(raw)
         if not device:
             match = difflib.get_close_matches(needle, list(names) + list(identifiers), n=1, cutoff=.58)
             device = (names.get(match[0]) or identifiers.get(match[0])) if match else None
@@ -173,14 +194,12 @@ class ServerSuite(commands.Cog):
             raise ValueError(f"I could not match “{device_text}” to an Apple device.")
         return device
 
-    async def _resolve_signing(self, question: str):
-        version_match = re.search(r"(?:ios\s*)?(\d+(?:\.\d+){1,2})", question, re.I)
-        device_text = re.split(r"\bfor\b", question, flags=re.I)[-1].strip(" ?.!")
-        device_text = re.sub(r"\b(is|signed|signing|ios|ipados)\b|\d+(?:\.\d+){1,2}", " ", device_text, flags=re.I).strip()
-        if not version_match or not device_text:
-            raise ValueError("Ask like: Is iOS 17.1 signed for iPhone 16?")
+    async def _check_signing(self, device_text: str, version: str):
+        version_match = re.search(r"\d+(?:\.\d+){1,2}", version)
+        if not version_match:
+            raise ValueError("Enter an iOS version such as 18.6 or 26.0.")
         device = await self._find_device(device_text)
-        version = version_match.group(1)
+        version = version_match.group(0)
         data = await self._get_json(f"{IPSW_API}/device/{device['identifier']}?type=ipsw")
         firmware = next((item for item in data.get("firmwares", []) if item.get("version") == version), None)
         if not firmware:
@@ -202,22 +221,27 @@ class ServerSuite(commands.Cog):
                     try:
                         output, _ = await asyncio.wait_for(process.communicate(), timeout=45)
                     except asyncio.TimeoutError:
-                        process.kill()
-                        await process.communicate()
-                        raise
+                        process.kill(); await process.communicate(); raise
                 text = output.decode(errors="replace")
                 if "IS being signed" in text: result = True
                 elif "IS NOT being signed" in text: result = False
             except (OSError, asyncio.TimeoutError):
                 logger.exception("TSSChecker signing request failed")
             finally:
-                if work_dir:
-                    shutil.rmtree(work_dir, ignore_errors=True)
+                if work_dir: shutil.rmtree(work_dir, ignore_errors=True)
         catalog_signed = bool(firmware.get("signed"))
         if result is not None and result != catalog_signed:
             return device, version, "uncertain", "TSSChecker and the firmware catalog disagree. Try again later before restoring."
         signed = catalog_signed if result is None else result
         return device, version, "signed" if signed else "unsigned", "Checked with TSSChecker and Apple's signing data."
+
+    async def _resolve_signing(self, question: str):
+        version_match = re.search(r"(?:ios\s*)?(\d+(?:\.\d+){1,2})", question, re.I)
+        device_text = re.split(r"\bfor\b", question, flags=re.I)[-1].strip(" ?.!")
+        device_text = re.sub(r"\b(is|signed|signing|ios|ipados)\b|\d+(?:\.\d+){1,2}", " ", device_text, flags=re.I).strip()
+        if not version_match or not device_text:
+            raise ValueError("Ask like: Is iOS 17.1 signed for iPhone 16?")
+        return await self._check_signing(device_text, version_match.group(1))
 
     async def _current_signing_summary(self):
         """Return a useful live result when /tss check has no question."""
@@ -248,18 +272,15 @@ class ServerSuite(commands.Cog):
             timestamp=datetime.now(timezone.utc),
         ).set_footer(text="Live result from Apple's firmware signing catalog via IPSW.me")
 
-    @tss.command(name="check", description="Check signing now, or ask about a version and device")
-    @app_commands.describe(question="Example: Is iOS 17.1 signed for iPhone 16?")
-    async def tss_check(self, interaction: discord.Interaction, question: str = ""):
+    @tss.command(name="check", description="Check whether an iOS version is signed for a device")
+    @app_commands.describe(
+        device="Apple device name or identifier, such as iPhone X or iPhone10,3",
+        ios_version="iOS or iPadOS version, such as 16.7.12 or 26.0",
+    )
+    async def tss_check(self, interaction: discord.Interaction, device: str, ios_version: str):
         await interaction.response.defer()
-        if not question.strip():
-            try:
-                await interaction.followup.send(embed=await self._current_signing_summary())
-            except aiohttp.ClientError:
-                await interaction.followup.send("I could not reach Apple's firmware signing catalog right now.", ephemeral=True)
-            return
         try:
-            device, version, status_code, note = await self._resolve_signing(question)
+            device, version, status_code, note = await self._check_signing(device, ios_version)
         except (ValueError, aiohttp.ClientError) as error:
             await interaction.followup.send(str(error), ephemeral=True); return
         status, color = {
@@ -271,6 +292,40 @@ class ServerSuite(commands.Cog):
                               timestamp=datetime.now(timezone.utc))
         embed.add_field(name="Device identifier", value=device["identifier"])
         await interaction.followup.send(embed=embed)
+
+    @tss_check.autocomplete("device")
+    async def tss_device_autocomplete(self, interaction: discord.Interaction, current: str):
+        try:
+            devices = await self._get_devices()
+        except aiohttp.ClientError:
+            return []
+        needle = self._normalise_device_name(current)
+        ranked = []
+        for item in devices:
+            name = str(item.get("name", ""))
+            identifier = str(item.get("identifier", ""))
+            haystack = self._normalise_device_name(f"{name} {identifier}")
+            if needle and needle not in haystack:
+                continue
+            family_rank = 0 if name.startswith(("iPhone", "iPad")) else 1
+            ranked.append((family_rank, name.casefold(), name, identifier))
+        ranked.sort()
+        return [app_commands.Choice(name=f"{name} · {identifier}"[:100], value=identifier[:100])
+                for _, _, name, identifier in ranked[:25]]
+
+    @tss_check.autocomplete("ios_version")
+    async def tss_version_autocomplete(self, interaction: discord.Interaction, current: str):
+        device_text = str(getattr(interaction.namespace, "device", "") or "")
+        if not device_text:
+            return []
+        try:
+            device = await self._find_device(device_text)
+            data = await self._get_json(f"{IPSW_API}/device/{device['identifier']}?type=ipsw")
+        except (ValueError, aiohttp.ClientError):
+            return []
+        versions = list(dict.fromkeys(str(item.get("version")) for item in data.get("firmwares", []) if item.get("version")))
+        matches = [version for version in versions if not current or version.startswith(current.strip())]
+        return [app_commands.Choice(name=version, value=version) for version in matches[:25]]
 
     @tss.command(name="device", description="Find the identifier GIR uses for an Apple device")
     async def tss_device(self, interaction: discord.Interaction, device: str):
@@ -307,7 +362,7 @@ class ServerSuite(commands.Cog):
     async def tss_help(self, interaction: discord.Interaction):
         await interaction.response.send_message(
             "**TSS commands**\n"
-            "`/tss check question:Is iOS 17.1 signed for iPhone 16?`\n"
+            "`/tss check device:iPhone 16 ios_version:18.0`\n"
             "`/tss device device:iPhone 16`\n"
             "`/tss versions device:iPhone 16`\n"
             "`/tss status`",

--- a/cogs/server_suite.py
+++ b/cogs/server_suite.py
@@ -4,28 +4,24 @@ from __future__ import annotations
 import asyncio
 import difflib
 import hashlib
-import json
 import os
 import random
 import re
-import xml.etree.ElementTree as ET
 from datetime import datetime, timezone
 from pathlib import Path
 
 import aiohttp
 import discord
 from discord import app_commands
-from discord.ext import commands, tasks
+from discord.ext import commands
 
-from cogs.community_suite import DATA_FILE, load_settings
 from utils import cfg, logger
 
 
 IPSW_API = "https://api.ipsw.me/v4"
 APPLE_EVENTS = "https://www.apple.com/apple-events/"
-APPLE_RSS = "https://www.apple.com/newsroom/rss-feed.rss"
+APPLE_NEWSROOM = "https://www.apple.com/newsroom/"
 TSSCHECKER = os.environ.get("TSSCHECKER_PATH", str(Path.home() / "Library/Application Support/SowensServer/bin/tsschecker"))
-APPLE_STATE = Path(os.environ.get("GIR_COMMUNITY_FILE", "community.json")).with_name("apple-events-state.json")
 
 QUESTIONS = (
     "What small thing made your day better?", "What game deserves a remake?", "What is your perfect weekend?",
@@ -42,17 +38,13 @@ class ServerSuite(commands.Cog):
     engage = app_commands.Group(name="engage", description="Games and friendly community activities", guild_ids=[cfg.guild_id])
     modtools = app_commands.Group(name="modtools", description="Extra tools for moderators", guild_ids=[cfg.guild_id],
                                   default_permissions=discord.Permissions(manage_messages=True))
-    apple = app_commands.Group(name="apple", description="Apple events and firmware signing", guild_ids=[cfg.guild_id])
+    apple = app_commands.Group(name="apple", description="Official Apple event and developer links", guild_ids=[cfg.guild_id])
     tss = app_commands.Group(name="tss", description="Check Apple firmware signing and device support", guild_ids=[cfg.guild_id])
 
     def __init__(self, bot: commands.Bot):
         self.bot = bot
         self._devices = []
         self._device_cache_time = 0.0
-        self.apple_event_check.start()
-
-    def cog_unload(self):
-        self.apple_event_check.cancel()
 
     @engage.command(name="eightball", description="Ask GIR a yes-or-no question")
     async def eightball(self, interaction: discord.Interaction, question: str):
@@ -314,86 +306,13 @@ class ServerSuite(commands.Cog):
     async def apple_events(self, interaction: discord.Interaction):
         await interaction.response.send_message(f"🍎 Apple event schedule and replays: {APPLE_EVENTS}")
 
-    @apple.command(name="latest", description="Show the latest item in Apple's official Newsroom feed")
+    @apple.command(name="latest", description="Open Apple's official Newsroom")
     async def apple_latest(self, interaction: discord.Interaction):
-        await interaction.response.defer()
-        try:
-            async with aiohttp.ClientSession(headers={"User-Agent": "GIR/1.0"}) as session:
-                async with session.get(APPLE_RSS, timeout=25) as response:
-                    response.raise_for_status(); root = ET.fromstring(await response.text())
-            item = root.find("./channel/item")
-            await interaction.followup.send(f"🍎 **{item.findtext('title')}**\n{item.findtext('link')}")
-        except Exception:
-            await interaction.followup.send("I could not reach Apple Newsroom right now.", ephemeral=True)
+        await interaction.response.send_message(f"🍎 Apple Newsroom: {APPLE_NEWSROOM}")
 
     @apple.command(name="developer", description="Open Apple's developer event schedule")
     async def apple_developer(self, interaction: discord.Interaction):
         await interaction.response.send_message("Apple developer sessions, labs, and events: https://developer.apple.com/events/")
-
-    def _save_apple_settings(self, enabled: bool, channel_id: int = 0, role_id: int = 0):
-        try: current = json.loads(DATA_FILE.read_text())
-        except (OSError, ValueError): current = {}
-        current["appleEvents"] = {"enabled": enabled, "channelID": channel_id, "roleID": role_id}
-        DATA_FILE.parent.mkdir(parents=True, exist_ok=True)
-        temporary = DATA_FILE.with_suffix(".tmp"); temporary.write_text(json.dumps(current, indent=2) + "\n"); temporary.replace(DATA_FILE)
-
-    @app_commands.default_permissions(manage_guild=True)
-    @apple.command(name="subscribe", description="Send Apple event alerts to a channel")
-    async def apple_subscribe(self, interaction: discord.Interaction, channel: discord.TextChannel, role: discord.Role = None):
-        self._save_apple_settings(True, channel.id, role.id if role else 0)
-        await interaction.response.send_message(f"Apple event alerts will be posted in {channel.mention}.", ephemeral=True)
-
-    @app_commands.default_permissions(manage_guild=True)
-    @apple.command(name="unsubscribe", description="Turn off Apple event alerts")
-    async def apple_unsubscribe(self, interaction: discord.Interaction):
-        self._save_apple_settings(False)
-        await interaction.response.send_message("Apple event alerts are off.", ephemeral=True)
-
-    @apple.command(name="status", description="Show Apple event alert settings")
-    async def apple_status(self, interaction: discord.Interaction):
-        settings = load_settings().get("appleEvents", {})
-        channel = interaction.guild.get_channel(int(settings.get("channelID", 0)))
-        await interaction.response.send_message(
-            f"Apple event alerts are **{'on' if settings.get('enabled') else 'off'}**"
-            + (f" in {channel.mention}." if channel else "."), ephemeral=True)
-
-    @tasks.loop(minutes=30)
-    async def apple_event_check(self):
-        settings = load_settings().get("appleEvents", {})
-        if not settings.get("enabled"):
-            return
-        channel = self.bot.get_channel(int(settings.get("channelID", 0)))
-        if not channel:
-            return
-        try:
-            async with aiohttp.ClientSession(headers={"User-Agent": "GIR/1.0"}) as session:
-                async with session.get(APPLE_RSS, timeout=25) as response:
-                    response.raise_for_status(); body = await response.text()
-            root = ET.fromstring(body)
-            event_items = []
-            for item in root.findall("./channel/item"):
-                title, link = item.findtext("title", ""), item.findtext("link", "")
-                searchable = title + " " + item.findtext("description", "")
-                if re.search(r"\b(apple event|wwdc|keynote|worldwide developers conference)\b", searchable, re.I):
-                    event_items.append({"title": title, "link": link})
-            try: seen = set(json.loads(APPLE_STATE.read_text()).get("seen", []))
-            except (OSError, ValueError): seen = set()
-            current = {item["link"] for item in event_items if item["link"]}
-            APPLE_STATE.parent.mkdir(parents=True, exist_ok=True)
-            APPLE_STATE.write_text(json.dumps({"seen": sorted(current), "checkedAt": datetime.now(timezone.utc).isoformat()}))
-            new_items = [item for item in event_items if seen and item["link"] not in seen]
-            for item in reversed(new_items[:3]):
-                role = channel.guild.get_role(int(settings.get("roleID", 0)))
-                await channel.send(content=role.mention if role else None,
-                    embed=discord.Embed(title=item["title"][:256], description=f"[Read the official Apple announcement]({item['link']})\n\n[Apple Events]({APPLE_EVENTS})", color=discord.Color.red()),
-                    allowed_mentions=discord.AllowedMentions(roles=True))
-        except Exception:
-            logger.exception("Apple event check failed")
-
-    @apple_event_check.before_loop
-    async def before_apple_event_check(self):
-        await self.bot.wait_until_ready()
-
 
 async def setup(bot):
     await bot.add_cog(ServerSuite(bot))

--- a/cogs/server_suite.py
+++ b/cogs/server_suite.py
@@ -188,6 +188,9 @@ class ServerSuite(commands.Cog):
         needle = self._normalise_device_name(device_text)
         device = names.get(needle) or identifiers.get(raw)
         if not device:
+            prefix_matches = [item for name, item in names.items() if name.startswith(needle + " ")]
+            device = prefix_matches[0] if prefix_matches else None
+        if not device:
             match = difflib.get_close_matches(needle, list(names) + list(identifiers), n=1, cutoff=.58)
             device = (names.get(match[0]) or identifiers.get(match[0])) if match else None
         if not device:

--- a/cogs/server_suite.py
+++ b/cogs/server_suite.py
@@ -8,6 +8,8 @@ import json
 import os
 import random
 import re
+import shutil
+import tempfile
 import xml.etree.ElementTree as ET
 from datetime import datetime, timezone
 from pathlib import Path
@@ -25,6 +27,8 @@ IPSW_API = "https://api.ipsw.me/v4"
 APPLE_EVENTS = "https://www.apple.com/apple-events/"
 APPLE_RSS = "https://www.apple.com/newsroom/rss-feed.rss"
 TSSCHECKER = os.environ.get("TSSCHECKER_PATH", str(Path.home() / "Library/Application Support/SowensServer/bin/tsschecker"))
+TSS_WORK_ROOT = Path(os.environ.get("GIR_TSS_WORK_ROOT", "/Volumes/4TB/Services/TSSChecker/runtime"))
+TSS_CONCURRENCY = asyncio.Semaphore(2)
 APPLE_STATE = Path(os.environ.get("GIR_COMMUNITY_FILE", "community.json")).with_name("apple-events-state.json")
 
 QUESTIONS = (
@@ -178,15 +182,32 @@ class ServerSuite(commands.Cog):
             return device, version, "incompatible", "That iOS version was not released for this device."
         result = None
         if Path(TSSCHECKER).is_file():
+            work_dir = None
             try:
-                process = await asyncio.create_subprocess_exec(TSSCHECKER, "-d", device["identifier"], "-i", version, "-b",
-                    stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT)
-                output, _ = await asyncio.wait_for(process.communicate(), timeout=45)
+                TSS_WORK_ROOT.mkdir(parents=True, exist_ok=True)
+                work_dir = Path(tempfile.mkdtemp(prefix="request-", dir=TSS_WORK_ROOT))
+                environment = os.environ.copy()
+                environment.update({"TMPDIR": str(work_dir), "HOME": str(work_dir), "XDG_CACHE_HOME": str(work_dir / "cache")})
+                async with TSS_CONCURRENCY:
+                    process = await asyncio.create_subprocess_exec(
+                        TSSCHECKER, "-d", device["identifier"], "-i", version, "-b",
+                        stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT,
+                        cwd=work_dir, env=environment,
+                    )
+                    try:
+                        output, _ = await asyncio.wait_for(process.communicate(), timeout=45)
+                    except asyncio.TimeoutError:
+                        process.kill()
+                        await process.communicate()
+                        raise
                 text = output.decode(errors="replace")
                 if "IS being signed" in text: result = True
                 elif "IS NOT being signed" in text: result = False
             except (OSError, asyncio.TimeoutError):
                 logger.exception("TSSChecker signing request failed")
+            finally:
+                if work_dir:
+                    shutil.rmtree(work_dir, ignore_errors=True)
         catalog_signed = bool(firmware.get("signed"))
         if result is not None and result != catalog_signed:
             return device, version, "uncertain", "TSSChecker and the firmware catalog disagree. Try again later before restoring."

--- a/cogs/server_suite.py
+++ b/cogs/server_suite.py
@@ -47,6 +47,7 @@ class ServerSuite(commands.Cog):
     modtools = app_commands.Group(name="modtools", description="Extra tools for moderators", guild_ids=[cfg.guild_id],
                                   default_permissions=discord.Permissions(manage_messages=True))
     apple = app_commands.Group(name="apple", description="Apple events and firmware signing", guild_ids=[cfg.guild_id])
+    tss = app_commands.Group(name="tss", description="Check Apple firmware signing and device support", guild_ids=[cfg.guild_id])
 
     def __init__(self, bot: commands.Bot):
         self.bot = bot
@@ -159,22 +160,26 @@ class ServerSuite(commands.Cog):
             async with session.get(url, timeout=25) as response:
                 response.raise_for_status(); return await response.json()
 
-    async def _resolve_signing(self, question: str):
-        version_match = re.search(r"(?:ios\s*)?(\d+(?:\.\d+){1,2})", question, re.I)
-        device_text = re.split(r"\bfor\b", question, flags=re.I)[-1].strip(" ?.!")
-        device_text = re.sub(r"\b(is|signed|signing|ios|ipados)\b|\d+(?:\.\d+){1,2}", " ", device_text, flags=re.I).strip()
-        if not version_match or not device_text:
-            raise ValueError("Ask like: Is iOS 17.1 signed for iPhone 16?")
+    async def _find_device(self, device_text: str):
         devices = await self._get_json(IPSW_API + "/devices")
         names = {str(item["name"]).lower(): item for item in devices}
         identifiers = {str(item["identifier"]).lower(): item for item in devices}
-        needle = device_text.lower()
+        needle = device_text.strip().lower()
         device = names.get(needle) or identifiers.get(needle)
         if not device:
             match = difflib.get_close_matches(needle, list(names) + list(identifiers), n=1, cutoff=.58)
             device = (names.get(match[0]) or identifiers.get(match[0])) if match else None
         if not device:
             raise ValueError(f"I could not match “{device_text}” to an Apple device.")
+        return device
+
+    async def _resolve_signing(self, question: str):
+        version_match = re.search(r"(?:ios\s*)?(\d+(?:\.\d+){1,2})", question, re.I)
+        device_text = re.split(r"\bfor\b", question, flags=re.I)[-1].strip(" ?.!")
+        device_text = re.sub(r"\b(is|signed|signing|ios|ipados)\b|\d+(?:\.\d+){1,2}", " ", device_text, flags=re.I).strip()
+        if not version_match or not device_text:
+            raise ValueError("Ask like: Is iOS 17.1 signed for iPhone 16?")
+        device = await self._find_device(device_text)
         version = version_match.group(1)
         data = await self._get_json(f"{IPSW_API}/device/{device['identifier']}?type=ipsw")
         firmware = next((item for item in data.get("firmwares", []) if item.get("version") == version), None)
@@ -214,9 +219,8 @@ class ServerSuite(commands.Cog):
         signed = catalog_signed if result is None else result
         return device, version, "signed" if signed else "unsigned", "Checked with TSSChecker and Apple's signing data."
 
-    @app_commands.guilds(cfg.guild_id)
-    @app_commands.command(name="signed", description="Ask naturally whether an iOS version is signed for a device")
-    async def signed(self, interaction: discord.Interaction, question: str):
+    @tss.command(name="check", description="Ask naturally whether an iOS version is signed for a device")
+    async def tss_check(self, interaction: discord.Interaction, question: str):
         await interaction.response.defer()
         try:
             device, version, status_code, note = await self._resolve_signing(question)
@@ -231,6 +235,48 @@ class ServerSuite(commands.Cog):
                               timestamp=datetime.now(timezone.utc))
         embed.add_field(name="Device identifier", value=device["identifier"])
         await interaction.followup.send(embed=embed)
+
+    @tss.command(name="device", description="Find the identifier GIR uses for an Apple device")
+    async def tss_device(self, interaction: discord.Interaction, device: str):
+        await interaction.response.defer(ephemeral=True)
+        try:
+            match = await self._find_device(device)
+            await interaction.followup.send(f"**{match['name']}** uses identifier `{match['identifier']}`.", ephemeral=True)
+        except (ValueError, aiohttp.ClientError) as error:
+            await interaction.followup.send(str(error), ephemeral=True)
+
+    @tss.command(name="versions", description="List currently signed iOS versions for a device")
+    async def tss_versions(self, interaction: discord.Interaction, device: str):
+        await interaction.response.defer()
+        try:
+            match = await self._find_device(device)
+            data = await self._get_json(f"{IPSW_API}/device/{match['identifier']}?type=ipsw")
+            signed = [item.get("version") for item in data.get("firmwares", []) if item.get("signed")]
+            versions = list(dict.fromkeys(value for value in signed if value))
+            text = ", ".join(versions[:20]) or "No signed iOS versions were reported."
+            await interaction.followup.send(f"**TSS signing for {match['name']}**\n{text}")
+        except (ValueError, aiohttp.ClientError) as error:
+            await interaction.followup.send(str(error), ephemeral=True)
+
+    @tss.command(name="status", description="Check whether GIR's signing checker is ready")
+    async def tss_status(self, interaction: discord.Interaction):
+        installed = Path(TSSCHECKER).is_file()
+        await interaction.response.send_message(
+            f"**TSS Checker:** {'Ready' if installed else 'Catalog fallback only'}\n"
+            "Checks use temporary external-drive storage and clean it after every request. No IPSW is downloaded.",
+            ephemeral=True,
+        )
+
+    @tss.command(name="help", description="Show examples of every TSS command")
+    async def tss_help(self, interaction: discord.Interaction):
+        await interaction.response.send_message(
+            "**TSS commands**\n"
+            "`/tss check question:Is iOS 17.1 signed for iPhone 16?`\n"
+            "`/tss device device:iPhone 16`\n"
+            "`/tss versions device:iPhone 16`\n"
+            "`/tss status`",
+            ephemeral=True,
+        )
 
     @apple.command(name="events", description="Open Apple's official event page")
     async def apple_events(self, interaction: discord.Interaction):

--- a/cogs/server_suite.py
+++ b/cogs/server_suite.py
@@ -8,8 +8,6 @@ import json
 import os
 import random
 import re
-import shutil
-import tempfile
 import xml.etree.ElementTree as ET
 from datetime import datetime, timezone
 from pathlib import Path
@@ -27,8 +25,6 @@ IPSW_API = "https://api.ipsw.me/v4"
 APPLE_EVENTS = "https://www.apple.com/apple-events/"
 APPLE_RSS = "https://www.apple.com/newsroom/rss-feed.rss"
 TSSCHECKER = os.environ.get("TSSCHECKER_PATH", str(Path.home() / "Library/Application Support/SowensServer/bin/tsschecker"))
-TSS_WORK_ROOT = Path(os.environ.get("GIR_TSS_WORK_ROOT", "/Volumes/4TB/Services/TSSChecker/runtime"))
-TSS_CONCURRENCY = asyncio.Semaphore(2)
 APPLE_STATE = Path(os.environ.get("GIR_COMMUNITY_FILE", "community.json")).with_name("apple-events-state.json")
 
 QUESTIONS = (
@@ -157,7 +153,7 @@ class ServerSuite(commands.Cog):
 
     async def _get_json(self, url: str):
         async with aiohttp.ClientSession(headers={"User-Agent": "GIR/1.0"}) as session:
-            async with session.get(url, timeout=25) as response:
+            async with session.get(url, timeout=aiohttp.ClientTimeout(total=10)) as response:
                 response.raise_for_status(); return await response.json()
 
     async def _get_devices(self):
@@ -207,73 +203,8 @@ class ServerSuite(commands.Cog):
         firmware = next((item for item in data.get("firmwares", []) if item.get("version") == version), None)
         if not firmware:
             return device, version, "incompatible", "That iOS version was not released for this device."
-        result = None
-        if Path(TSSCHECKER).is_file():
-            work_dir = None
-            try:
-                TSS_WORK_ROOT.mkdir(parents=True, exist_ok=True)
-                work_dir = Path(tempfile.mkdtemp(prefix="request-", dir=TSS_WORK_ROOT))
-                environment = os.environ.copy()
-                environment.update({"TMPDIR": str(work_dir), "HOME": str(work_dir), "XDG_CACHE_HOME": str(work_dir / "cache")})
-                async with TSS_CONCURRENCY:
-                    process = await asyncio.create_subprocess_exec(
-                        TSSCHECKER, "-d", device["identifier"], "-i", version, "-b",
-                        stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT,
-                        cwd=work_dir, env=environment,
-                    )
-                    try:
-                        output, _ = await asyncio.wait_for(process.communicate(), timeout=45)
-                    except asyncio.TimeoutError:
-                        process.kill(); await process.communicate(); raise
-                text = output.decode(errors="replace")
-                if "IS being signed" in text: result = True
-                elif "IS NOT being signed" in text: result = False
-            except (OSError, asyncio.TimeoutError):
-                logger.exception("TSSChecker signing request failed")
-            finally:
-                if work_dir: shutil.rmtree(work_dir, ignore_errors=True)
-        catalog_signed = bool(firmware.get("signed"))
-        if result is not None and result != catalog_signed:
-            return device, version, "uncertain", "TSSChecker and the firmware catalog disagree. Try again later before restoring."
-        signed = catalog_signed if result is None else result
-        return device, version, "signed" if signed else "unsigned", "Checked with TSSChecker and Apple's signing data."
-
-    async def _resolve_signing(self, question: str):
-        version_match = re.search(r"(?:ios\s*)?(\d+(?:\.\d+){1,2})", question, re.I)
-        device_text = re.split(r"\bfor\b", question, flags=re.I)[-1].strip(" ?.!")
-        device_text = re.sub(r"\b(is|signed|signing|ios|ipados)\b|\d+(?:\.\d+){1,2}", " ", device_text, flags=re.I).strip()
-        if not version_match or not device_text:
-            raise ValueError("Ask like: Is iOS 17.1 signed for iPhone 16?")
-        return await self._check_signing(device_text, version_match.group(1))
-
-    async def _current_signing_summary(self):
-        """Return a useful live result when /tss check has no question."""
-        devices = await self._get_json(IPSW_API + "/devices")
-        preferred_names = ("iPhone 16", "iPhone 16 Pro", "iPhone 15", "iPad Pro 11-inch (M4)")
-        by_name = {str(item.get("name", "")).lower(): item for item in devices}
-        selected = [by_name[name.lower()] for name in preferred_names if name.lower() in by_name]
-        if not selected:
-            selected = [item for item in devices if str(item.get("name", "")).startswith("iPhone")][-4:]
-
-        async def signed_versions(device):
-            data = await self._get_json(f"{IPSW_API}/device/{device['identifier']}?type=ipsw")
-            versions = list(dict.fromkeys(
-                item.get("version") for item in data.get("firmwares", [])
-                if item.get("signed") and item.get("version")
-            ))
-            return device, versions
-
-        results = await asyncio.gather(*(signed_versions(device) for device in selected))
-        lines = [
-            f"**{device['name']}** (`{device['identifier']}`): " + (", ".join(versions[:8]) or "None reported")
-            for device, versions in results
-        ]
-        return discord.Embed(
-            title="Currently signed Apple firmware",
-            description="\n".join(lines),
-            color=discord.Color.green(),
-            timestamp=datetime.now(timezone.utc),
-        ).set_footer(text="Live result from Apple's firmware signing catalog via IPSW.me")
+        signed = bool(firmware.get("signed"))
+        return device, version, "signed" if signed else "unsigned", "Checked against the live Apple firmware signing catalog."
 
     @tss.command(name="check", description="Check whether an iOS version is signed for a device")
     @app_commands.describe(
@@ -283,7 +214,13 @@ class ServerSuite(commands.Cog):
     async def tss_check(self, interaction: discord.Interaction, device: str, ios_version: str):
         await interaction.response.defer()
         try:
-            device, version, status_code, note = await self._check_signing(device, ios_version)
+            device, version, status_code, note = await asyncio.wait_for(
+                self._check_signing(device, ios_version), timeout=25
+            )
+        except asyncio.TimeoutError:
+            await interaction.followup.send(
+                "The signing catalog did not answer within 25 seconds. Please try again.", ephemeral=True
+            ); return
         except (ValueError, aiohttp.ClientError) as error:
             await interaction.followup.send(str(error), ephemeral=True); return
         status, color = {
@@ -356,8 +293,9 @@ class ServerSuite(commands.Cog):
     async def tss_status(self, interaction: discord.Interaction):
         installed = Path(TSSCHECKER).is_file()
         await interaction.response.send_message(
-            f"**TSS Checker:** {'Ready' if installed else 'Catalog fallback only'}\n"
-            "Checks use temporary external-drive storage and clean it after every request. No IPSW is downloaded.",
+            "**Fast signing checks:** Ready\n"
+            "Interactive checks use the live firmware catalog and have a 25-second deadline. No IPSW is downloaded.\n"
+            f"**Local TSSChecker utility:** {'Installed (not used for interactive checks)' if installed else 'Not installed'}",
             ephemeral=True,
         )
 

--- a/cogs/server_suite.py
+++ b/cogs/server_suite.py
@@ -1,0 +1,300 @@
+"""Server-aware engagement, moderation, Apple event, and firmware tools."""
+from __future__ import annotations
+
+import asyncio
+import difflib
+import hashlib
+import json
+import os
+import random
+import re
+import xml.etree.ElementTree as ET
+from datetime import datetime, timezone
+from pathlib import Path
+
+import aiohttp
+import discord
+from discord import app_commands
+from discord.ext import commands, tasks
+
+from cogs.community_suite import DATA_FILE, load_settings
+from utils import cfg, logger
+
+
+IPSW_API = "https://api.ipsw.me/v4"
+APPLE_EVENTS = "https://www.apple.com/apple-events/"
+APPLE_RSS = "https://www.apple.com/newsroom/rss-feed.rss"
+TSSCHECKER = os.environ.get("TSSCHECKER_PATH", str(Path.home() / "Library/Application Support/SowensServer/bin/tsschecker"))
+APPLE_STATE = Path(os.environ.get("GIR_COMMUNITY_FILE", "community.json")).with_name("apple-events-state.json")
+
+QUESTIONS = (
+    "What small thing made your day better?", "What game deserves a remake?", "What is your perfect weekend?",
+    "Which skill would you learn instantly?", "What song never gets old?", "What is your favorite comfort food?",
+)
+WOULD_YOU_RATHER = (
+    "Would you rather explore space or the deepest ocean?", "Would you rather have unlimited travel or unlimited food?",
+    "Would you rather always be ten minutes early or never wait in line?", "Would you rather relive one day or skip one bad day?",
+)
+COMPLIMENTS = ("brings great energy", "makes this server more fun", "has excellent taste", "is someone people can count on")
+
+
+class ServerSuite(commands.Cog):
+    engage = app_commands.Group(name="engage", description="Games and friendly community activities", guild_ids=[cfg.guild_id])
+    modtools = app_commands.Group(name="modtools", description="Extra tools for moderators", guild_ids=[cfg.guild_id],
+                                  default_permissions=discord.Permissions(manage_messages=True))
+    apple = app_commands.Group(name="apple", description="Apple events and firmware signing", guild_ids=[cfg.guild_id])
+
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+        self._devices = []
+        self._device_cache_time = 0.0
+        self.apple_event_check.start()
+
+    def cog_unload(self):
+        self.apple_event_check.cancel()
+
+    @engage.command(name="eightball", description="Ask GIR a yes-or-no question")
+    async def eightball(self, interaction: discord.Interaction, question: str):
+        answer = random.choice(("Yes.", "Probably.", "Signs point to yes.", "Ask again later.", "Probably not.", "No."))
+        await interaction.response.send_message(f"🎱 **{question[:300]}**\n{answer}")
+
+    @engage.command(name="question", description="Post a conversation starter")
+    async def question(self, interaction: discord.Interaction):
+        await interaction.response.send_message("💬 " + random.choice(QUESTIONS))
+
+    @engage.command(name="would-you-rather", description="Post a would-you-rather question")
+    async def would_you_rather(self, interaction: discord.Interaction):
+        await interaction.response.send_message("🤔 " + random.choice(WOULD_YOU_RATHER))
+
+    @engage.command(name="compliment", description="Send a friendly compliment")
+    async def compliment(self, interaction: discord.Interaction, member: discord.Member):
+        await interaction.response.send_message(f"✨ {member.mention} {random.choice(COMPLIMENTS)}.")
+
+    @engage.command(name="highfive", description="Give someone a high five")
+    async def highfive(self, interaction: discord.Interaction, member: discord.Member):
+        await interaction.response.send_message(f"🙌 {interaction.user.mention} high-fived {member.mention}!")
+
+    @engage.command(name="hug", description="Send someone a friendly hug")
+    async def hug(self, interaction: discord.Interaction, member: discord.Member):
+        await interaction.response.send_message(f"🫂 {interaction.user.mention} sent {member.mention} a hug.")
+
+    @engage.command(name="match", description="Calculate a repeatable friendship score")
+    async def match(self, interaction: discord.Interaction, first: discord.Member, second: discord.Member):
+        pair = ":".join(map(str, sorted((first.id, second.id)))).encode()
+        score = int(hashlib.sha256(pair).hexdigest()[:8], 16) % 101
+        await interaction.response.send_message(f"💚 {first.mention} + {second.mention}: **{score}%** match")
+
+    @engage.command(name="decide", description="Choose fairly from a list separated by commas")
+    async def decide(self, interaction: discord.Interaction, choices: str):
+        items = [item.strip() for item in choices.split(",") if item.strip()]
+        if len(items) < 2:
+            await interaction.response.send_message("Give me at least two choices separated by commas.", ephemeral=True); return
+        await interaction.response.send_message(f"🎯 GIR chooses **{random.choice(items)}**")
+
+    @engage.command(name="random-member", description="Choose a random non-bot member")
+    async def random_member(self, interaction: discord.Interaction):
+        choices = [member for member in interaction.guild.members if not member.bot]
+        if not choices:
+            await interaction.response.send_message("I could not find an eligible member.", ephemeral=True); return
+        await interaction.response.send_message(f"🎉 {random.choice(choices).mention} was chosen!")
+
+    @modtools.command(name="role-add", description="Give a manageable role to a member")
+    async def role_add(self, interaction: discord.Interaction, member: discord.Member, role: discord.Role):
+        if role >= interaction.guild.me.top_role or role.is_default() or role.managed:
+            await interaction.response.send_message("GIR cannot manage that role. Move GIR above it or choose another role.", ephemeral=True); return
+        await member.add_roles(role, reason=f"Added by {interaction.user}")
+        await interaction.response.send_message(f"Added {role.mention} to {member.mention}.", ephemeral=True)
+
+    @modtools.command(name="role-remove", description="Remove a manageable role from a member")
+    async def role_remove(self, interaction: discord.Interaction, member: discord.Member, role: discord.Role):
+        if role >= interaction.guild.me.top_role or role.is_default() or role.managed:
+            await interaction.response.send_message("GIR cannot manage that role. Move GIR above it or choose another role.", ephemeral=True); return
+        await member.remove_roles(role, reason=f"Removed by {interaction.user}")
+        await interaction.response.send_message(f"Removed {role.mention} from {member.mention}.", ephemeral=True)
+
+    @modtools.command(name="permissions", description="Explain what GIR can do to a member")
+    async def permissions(self, interaction: discord.Interaction, member: discord.Member):
+        manageable = member != interaction.guild.owner and member.top_role < interaction.guild.me.top_role
+        await interaction.response.send_message(
+            f"**{member.display_name}**\nTop role: {member.top_role.mention}\n"
+            f"GIR can moderate this member: **{'Yes' if manageable else 'No'}**\n"
+            f"Administrator: **{'Yes' if member.guild_permissions.administrator else 'No'}**", ephemeral=True)
+
+    @modtools.command(name="clear-reactions", description="Remove every reaction from a message")
+    async def clear_reactions(self, interaction: discord.Interaction, message_id: str):
+        if not message_id.isdigit():
+            await interaction.response.send_message("Enter a numeric message ID.", ephemeral=True); return
+        try:
+            message = await interaction.channel.fetch_message(int(message_id)); await message.clear_reactions()
+        except discord.HTTPException:
+            await interaction.response.send_message("I could not find that message or clear its reactions.", ephemeral=True); return
+        await interaction.response.send_message("Reactions cleared.", ephemeral=True)
+
+    @modtools.command(name="role-members", description="List members who have a role")
+    async def role_members(self, interaction: discord.Interaction, role: discord.Role):
+        names = [member.mention for member in role.members]
+        text = " ".join(names[:80]) or "No cached members have this role."
+        if len(names) > 80:
+            text += f"\n…and {len(names) - 80} more."
+        await interaction.response.send_message(f"**{role.name} · {len(names)} members**\n{text}"[:2000], ephemeral=True)
+
+    @modtools.command(name="channel-info", description="Show a channel's IDs, topic, and rate limit")
+    async def channel_info(self, interaction: discord.Interaction, channel: discord.TextChannel):
+        await interaction.response.send_message(
+            f"**#{channel.name}**\nID: `{channel.id}`\nCategory: {channel.category.name if channel.category else 'None'}\n"
+            f"Slow mode: {channel.slowmode_delay} seconds\nTopic: {channel.topic or 'None'}", ephemeral=True)
+
+    @modtools.command(name="bots", description="List bot accounts currently in the server cache")
+    async def bots(self, interaction: discord.Interaction):
+        bots = [member for member in interaction.guild.members if member.bot]
+        text = "\n".join(f"• {member} · `{member.id}`" for member in bots[:50]) or "No bots found."
+        await interaction.response.send_message(f"**Bots · {len(bots)}**\n{text}"[:2000], ephemeral=True)
+
+    async def _get_json(self, url: str):
+        async with aiohttp.ClientSession(headers={"User-Agent": "GIR/1.0"}) as session:
+            async with session.get(url, timeout=25) as response:
+                response.raise_for_status(); return await response.json()
+
+    async def _resolve_signing(self, question: str):
+        version_match = re.search(r"(?:ios\s*)?(\d+(?:\.\d+){1,2})", question, re.I)
+        device_text = re.split(r"\bfor\b", question, flags=re.I)[-1].strip(" ?.!")
+        device_text = re.sub(r"\b(is|signed|signing|ios|ipados)\b|\d+(?:\.\d+){1,2}", " ", device_text, flags=re.I).strip()
+        if not version_match or not device_text:
+            raise ValueError("Ask like: Is iOS 17.1 signed for iPhone 16?")
+        devices = await self._get_json(IPSW_API + "/devices")
+        names = {str(item["name"]).lower(): item for item in devices}
+        identifiers = {str(item["identifier"]).lower(): item for item in devices}
+        needle = device_text.lower()
+        device = names.get(needle) or identifiers.get(needle)
+        if not device:
+            match = difflib.get_close_matches(needle, list(names) + list(identifiers), n=1, cutoff=.58)
+            device = (names.get(match[0]) or identifiers.get(match[0])) if match else None
+        if not device:
+            raise ValueError(f"I could not match “{device_text}” to an Apple device.")
+        version = version_match.group(1)
+        data = await self._get_json(f"{IPSW_API}/device/{device['identifier']}?type=ipsw")
+        firmware = next((item for item in data.get("firmwares", []) if item.get("version") == version), None)
+        if not firmware:
+            return device, version, "incompatible", "That iOS version was not released for this device."
+        result = None
+        if Path(TSSCHECKER).is_file():
+            try:
+                process = await asyncio.create_subprocess_exec(TSSCHECKER, "-d", device["identifier"], "-i", version, "-b",
+                    stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT)
+                output, _ = await asyncio.wait_for(process.communicate(), timeout=45)
+                text = output.decode(errors="replace")
+                if "IS being signed" in text: result = True
+                elif "IS NOT being signed" in text: result = False
+            except (OSError, asyncio.TimeoutError):
+                logger.exception("TSSChecker signing request failed")
+        catalog_signed = bool(firmware.get("signed"))
+        if result is not None and result != catalog_signed:
+            return device, version, "uncertain", "TSSChecker and the firmware catalog disagree. Try again later before restoring."
+        signed = catalog_signed if result is None else result
+        return device, version, "signed" if signed else "unsigned", "Checked with TSSChecker and Apple's signing data."
+
+    @app_commands.guilds(cfg.guild_id)
+    @app_commands.command(name="signed", description="Ask naturally whether an iOS version is signed for a device")
+    async def signed(self, interaction: discord.Interaction, question: str):
+        await interaction.response.defer()
+        try:
+            device, version, status_code, note = await self._resolve_signing(question)
+        except (ValueError, aiohttp.ClientError) as error:
+            await interaction.followup.send(str(error), ephemeral=True); return
+        status, color = {
+            "signed": ("Signed", discord.Color.green()), "unsigned": ("Not signed", discord.Color.red()),
+            "incompatible": ("Not compatible", discord.Color.orange()),
+            "uncertain": ("Needs another check", discord.Color.orange()),
+        }[status_code]
+        embed = discord.Embed(title=f"{device['name']} · iOS {version}", description=f"**{status}**\n{note}", color=color,
+                              timestamp=datetime.now(timezone.utc))
+        embed.add_field(name="Device identifier", value=device["identifier"])
+        await interaction.followup.send(embed=embed)
+
+    @apple.command(name="events", description="Open Apple's official event page")
+    async def apple_events(self, interaction: discord.Interaction):
+        await interaction.response.send_message(f"🍎 Apple event schedule and replays: {APPLE_EVENTS}")
+
+    @apple.command(name="latest", description="Show the latest item in Apple's official Newsroom feed")
+    async def apple_latest(self, interaction: discord.Interaction):
+        await interaction.response.defer()
+        try:
+            async with aiohttp.ClientSession(headers={"User-Agent": "GIR/1.0"}) as session:
+                async with session.get(APPLE_RSS, timeout=25) as response:
+                    response.raise_for_status(); root = ET.fromstring(await response.text())
+            item = root.find("./channel/item")
+            await interaction.followup.send(f"🍎 **{item.findtext('title')}**\n{item.findtext('link')}")
+        except Exception:
+            await interaction.followup.send("I could not reach Apple Newsroom right now.", ephemeral=True)
+
+    @apple.command(name="developer", description="Open Apple's developer event schedule")
+    async def apple_developer(self, interaction: discord.Interaction):
+        await interaction.response.send_message("Apple developer sessions, labs, and events: https://developer.apple.com/events/")
+
+    def _save_apple_settings(self, enabled: bool, channel_id: int = 0, role_id: int = 0):
+        try: current = json.loads(DATA_FILE.read_text())
+        except (OSError, ValueError): current = {}
+        current["appleEvents"] = {"enabled": enabled, "channelID": channel_id, "roleID": role_id}
+        DATA_FILE.parent.mkdir(parents=True, exist_ok=True)
+        temporary = DATA_FILE.with_suffix(".tmp"); temporary.write_text(json.dumps(current, indent=2) + "\n"); temporary.replace(DATA_FILE)
+
+    @app_commands.default_permissions(manage_guild=True)
+    @apple.command(name="subscribe", description="Send Apple event alerts to a channel")
+    async def apple_subscribe(self, interaction: discord.Interaction, channel: discord.TextChannel, role: discord.Role = None):
+        self._save_apple_settings(True, channel.id, role.id if role else 0)
+        await interaction.response.send_message(f"Apple event alerts will be posted in {channel.mention}.", ephemeral=True)
+
+    @app_commands.default_permissions(manage_guild=True)
+    @apple.command(name="unsubscribe", description="Turn off Apple event alerts")
+    async def apple_unsubscribe(self, interaction: discord.Interaction):
+        self._save_apple_settings(False)
+        await interaction.response.send_message("Apple event alerts are off.", ephemeral=True)
+
+    @apple.command(name="status", description="Show Apple event alert settings")
+    async def apple_status(self, interaction: discord.Interaction):
+        settings = load_settings().get("appleEvents", {})
+        channel = interaction.guild.get_channel(int(settings.get("channelID", 0)))
+        await interaction.response.send_message(
+            f"Apple event alerts are **{'on' if settings.get('enabled') else 'off'}**"
+            + (f" in {channel.mention}." if channel else "."), ephemeral=True)
+
+    @tasks.loop(minutes=30)
+    async def apple_event_check(self):
+        settings = load_settings().get("appleEvents", {})
+        if not settings.get("enabled"):
+            return
+        channel = self.bot.get_channel(int(settings.get("channelID", 0)))
+        if not channel:
+            return
+        try:
+            async with aiohttp.ClientSession(headers={"User-Agent": "GIR/1.0"}) as session:
+                async with session.get(APPLE_RSS, timeout=25) as response:
+                    response.raise_for_status(); body = await response.text()
+            root = ET.fromstring(body)
+            event_items = []
+            for item in root.findall("./channel/item"):
+                title, link = item.findtext("title", ""), item.findtext("link", "")
+                searchable = title + " " + item.findtext("description", "")
+                if re.search(r"\b(apple event|wwdc|keynote|worldwide developers conference)\b", searchable, re.I):
+                    event_items.append({"title": title, "link": link})
+            try: seen = set(json.loads(APPLE_STATE.read_text()).get("seen", []))
+            except (OSError, ValueError): seen = set()
+            current = {item["link"] for item in event_items if item["link"]}
+            APPLE_STATE.parent.mkdir(parents=True, exist_ok=True)
+            APPLE_STATE.write_text(json.dumps({"seen": sorted(current), "checkedAt": datetime.now(timezone.utc).isoformat()}))
+            new_items = [item for item in event_items if seen and item["link"] not in seen]
+            for item in reversed(new_items[:3]):
+                role = channel.guild.get_role(int(settings.get("roleID", 0)))
+                await channel.send(content=role.mention if role else None,
+                    embed=discord.Embed(title=item["title"][:256], description=f"[Read the official Apple announcement]({item['link']})\n\n[Apple Events]({APPLE_EVENTS})", color=discord.Color.red()),
+                    allowed_mentions=discord.AllowedMentions(roles=True))
+        except Exception:
+            logger.exception("Apple event check failed")
+
+    @apple_event_check.before_loop
+    async def before_apple_event_check(self):
+        await self.bot.wait_until_ready()
+
+
+async def setup(bot):
+    await bot.add_cog(ServerSuite(bot))

--- a/cogs/server_suite.py
+++ b/cogs/server_suite.py
@@ -219,9 +219,45 @@ class ServerSuite(commands.Cog):
         signed = catalog_signed if result is None else result
         return device, version, "signed" if signed else "unsigned", "Checked with TSSChecker and Apple's signing data."
 
-    @tss.command(name="check", description="Ask naturally whether an iOS version is signed for a device")
-    async def tss_check(self, interaction: discord.Interaction, question: str):
+    async def _current_signing_summary(self):
+        """Return a useful live result when /tss check has no question."""
+        devices = await self._get_json(IPSW_API + "/devices")
+        preferred_names = ("iPhone 16", "iPhone 16 Pro", "iPhone 15", "iPad Pro 11-inch (M4)")
+        by_name = {str(item.get("name", "")).lower(): item for item in devices}
+        selected = [by_name[name.lower()] for name in preferred_names if name.lower() in by_name]
+        if not selected:
+            selected = [item for item in devices if str(item.get("name", "")).startswith("iPhone")][-4:]
+
+        async def signed_versions(device):
+            data = await self._get_json(f"{IPSW_API}/device/{device['identifier']}?type=ipsw")
+            versions = list(dict.fromkeys(
+                item.get("version") for item in data.get("firmwares", [])
+                if item.get("signed") and item.get("version")
+            ))
+            return device, versions
+
+        results = await asyncio.gather(*(signed_versions(device) for device in selected))
+        lines = [
+            f"**{device['name']}** (`{device['identifier']}`): " + (", ".join(versions[:8]) or "None reported")
+            for device, versions in results
+        ]
+        return discord.Embed(
+            title="Currently signed Apple firmware",
+            description="\n".join(lines),
+            color=discord.Color.green(),
+            timestamp=datetime.now(timezone.utc),
+        ).set_footer(text="Live result from Apple's firmware signing catalog via IPSW.me")
+
+    @tss.command(name="check", description="Check signing now, or ask about a version and device")
+    @app_commands.describe(question="Example: Is iOS 17.1 signed for iPhone 16?")
+    async def tss_check(self, interaction: discord.Interaction, question: str = ""):
         await interaction.response.defer()
+        if not question.strip():
+            try:
+                await interaction.followup.send(embed=await self._current_signing_summary())
+            except aiohttp.ClientError:
+                await interaction.followup.send("I could not reach Apple's firmware signing catalog right now.", ephemeral=True)
+            return
         try:
             device, version, status_code, note = await self._resolve_signing(question)
         except (ValueError, aiohttp.ClientError) as error:

--- a/cogs/server_suite.py
+++ b/cogs/server_suite.py
@@ -1,16 +1,9 @@
-"""Server-aware engagement, moderation, Apple event, and firmware tools."""
+"""Server-aware engagement and moderation tools."""
 from __future__ import annotations
 
-import asyncio
-import difflib
 import hashlib
-import os
 import random
-import re
-from datetime import datetime, timezone
-from pathlib import Path
 
-import aiohttp
 import discord
 from discord import app_commands
 from discord.ext import commands
@@ -18,10 +11,6 @@ from discord.ext import commands
 from utils import cfg, logger
 
 
-IPSW_API = "https://api.ipsw.me/v4"
-APPLE_EVENTS = "https://www.apple.com/apple-events/"
-APPLE_NEWSROOM = "https://www.apple.com/newsroom/"
-TSSCHECKER = os.environ.get("TSSCHECKER_PATH", str(Path.home() / "Library/Application Support/SowensServer/bin/tsschecker"))
 
 QUESTIONS = (
     "What small thing made your day better?", "What game deserves a remake?", "What is your perfect weekend?",
@@ -38,13 +27,9 @@ class ServerSuite(commands.Cog):
     engage = app_commands.Group(name="engage", description="Games and friendly community activities", guild_ids=[cfg.guild_id])
     modtools = app_commands.Group(name="modtools", description="Extra tools for moderators", guild_ids=[cfg.guild_id],
                                   default_permissions=discord.Permissions(manage_messages=True))
-    apple = app_commands.Group(name="apple", description="Official Apple event and developer links", guild_ids=[cfg.guild_id])
-    tss = app_commands.Group(name="tss", description="Check Apple firmware signing and device support", guild_ids=[cfg.guild_id])
 
     def __init__(self, bot: commands.Bot):
         self.bot = bot
-        self._devices = []
-        self._device_cache_time = 0.0
 
     @engage.command(name="eightball", description="Ask GIR a yes-or-no question")
     async def eightball(self, interaction: discord.Interaction, question: str):
@@ -143,176 +128,6 @@ class ServerSuite(commands.Cog):
         text = "\n".join(f"• {member} · `{member.id}`" for member in bots[:50]) or "No bots found."
         await interaction.response.send_message(f"**Bots · {len(bots)}**\n{text}"[:2000], ephemeral=True)
 
-    async def _get_json(self, url: str):
-        async with aiohttp.ClientSession(headers={"User-Agent": "GIR/1.0"}) as session:
-            async with session.get(url, timeout=aiohttp.ClientTimeout(total=10)) as response:
-                response.raise_for_status(); return await response.json()
-
-    async def _get_devices(self):
-        now = asyncio.get_running_loop().time()
-        if self._devices and now - self._device_cache_time < 3600:
-            return self._devices
-        self._devices = await self._get_json(IPSW_API + "/devices")
-        self._device_cache_time = now
-        return self._devices
-
-    @staticmethod
-    def _normalise_device_name(value: str):
-        value = value.casefold().replace("‑", "-")
-        value = re.sub(r"\b(1st|2nd|3rd|([4-9]|\d{2,})th)\s+(generation|gen)\b", r"\1", value)
-        value = re.sub(r"\b(first|second|third|fourth|fifth|sixth|seventh|eighth|ninth|tenth)\s+(generation|gen)\b", r"\1", value)
-        number_words = {"first": "1", "second": "2", "third": "3", "fourth": "4", "fifth": "5",
-                        "sixth": "6", "seventh": "7", "eighth": "8", "ninth": "9", "tenth": "10"}
-        for word, number in number_words.items():
-            value = re.sub(rf"\b{word}\b", number, value)
-        value = re.sub(r"(\d+)(st|nd|rd|th)\b", r"\1", value)
-        return re.sub(r"[^a-z0-9]+", " ", value).strip()
-
-    async def _find_device(self, device_text: str):
-        devices = await self._get_devices()
-        names = {self._normalise_device_name(str(item["name"])): item for item in devices}
-        identifiers = {str(item["identifier"]).casefold(): item for item in devices}
-        raw = device_text.strip().casefold()
-        needle = self._normalise_device_name(device_text)
-        device = names.get(needle) or identifiers.get(raw)
-        if not device:
-            prefix_matches = [item for name, item in names.items() if name.startswith(needle + " ")]
-            device = prefix_matches[0] if prefix_matches else None
-        if not device:
-            match = difflib.get_close_matches(needle, list(names) + list(identifiers), n=1, cutoff=.58)
-            device = (names.get(match[0]) or identifiers.get(match[0])) if match else None
-        if not device:
-            raise ValueError(f"I could not match “{device_text}” to an Apple device.")
-        return device
-
-    async def _check_signing(self, device_text: str, version: str):
-        version_match = re.search(r"\d+(?:\.\d+){1,2}", version)
-        if not version_match:
-            raise ValueError("Enter an iOS version such as 18.6 or 26.0.")
-        device = await self._find_device(device_text)
-        version = version_match.group(0)
-        data = await self._get_json(f"{IPSW_API}/device/{device['identifier']}?type=ipsw")
-        firmware = next((item for item in data.get("firmwares", []) if item.get("version") == version), None)
-        if not firmware:
-            return device, version, "incompatible", "That iOS version was not released for this device."
-        signed = bool(firmware.get("signed"))
-        return device, version, "signed" if signed else "unsigned", "Checked against the live Apple firmware signing catalog."
-
-    @tss.command(name="check", description="Check whether an iOS version is signed for a device")
-    @app_commands.describe(
-        device="Apple device name or identifier, such as iPhone X or iPhone10,3",
-        ios_version="iOS or iPadOS version, such as 16.7.12 or 26.0",
-    )
-    async def tss_check(self, interaction: discord.Interaction, device: str, ios_version: str):
-        await interaction.response.defer()
-        try:
-            device, version, status_code, note = await asyncio.wait_for(
-                self._check_signing(device, ios_version), timeout=25
-            )
-        except asyncio.TimeoutError:
-            await interaction.followup.send(
-                "The signing catalog did not answer within 25 seconds. Please try again.", ephemeral=True
-            ); return
-        except (ValueError, aiohttp.ClientError) as error:
-            await interaction.followup.send(str(error), ephemeral=True); return
-        status, color = {
-            "signed": ("Signed", discord.Color.green()), "unsigned": ("Not signed", discord.Color.red()),
-            "incompatible": ("Not compatible", discord.Color.orange()),
-            "uncertain": ("Needs another check", discord.Color.orange()),
-        }[status_code]
-        embed = discord.Embed(title=f"{device['name']} · iOS {version}", description=f"**{status}**\n{note}", color=color,
-                              timestamp=datetime.now(timezone.utc))
-        embed.add_field(name="Device identifier", value=device["identifier"])
-        await interaction.followup.send(embed=embed)
-
-    @tss_check.autocomplete("device")
-    async def tss_device_autocomplete(self, interaction: discord.Interaction, current: str):
-        try:
-            devices = await self._get_devices()
-        except aiohttp.ClientError:
-            return []
-        needle = self._normalise_device_name(current)
-        ranked = []
-        for item in devices:
-            name = str(item.get("name", ""))
-            identifier = str(item.get("identifier", ""))
-            haystack = self._normalise_device_name(f"{name} {identifier}")
-            if needle and needle not in haystack:
-                continue
-            family_rank = 0 if name.startswith(("iPhone", "iPad")) else 1
-            ranked.append((family_rank, name.casefold(), name, identifier))
-        ranked.sort()
-        return [app_commands.Choice(name=f"{name} · {identifier}"[:100], value=identifier[:100])
-                for _, _, name, identifier in ranked[:25]]
-
-    @tss_check.autocomplete("ios_version")
-    async def tss_version_autocomplete(self, interaction: discord.Interaction, current: str):
-        device_text = str(getattr(interaction.namespace, "device", "") or "")
-        if not device_text:
-            return []
-        try:
-            device = await self._find_device(device_text)
-            data = await self._get_json(f"{IPSW_API}/device/{device['identifier']}?type=ipsw")
-        except (ValueError, aiohttp.ClientError):
-            return []
-        versions = list(dict.fromkeys(str(item.get("version")) for item in data.get("firmwares", []) if item.get("version")))
-        matches = [version for version in versions if not current or version.startswith(current.strip())]
-        return [app_commands.Choice(name=version, value=version) for version in matches[:25]]
-
-    @tss.command(name="device", description="Find the identifier GIR uses for an Apple device")
-    async def tss_device(self, interaction: discord.Interaction, device: str):
-        await interaction.response.defer(ephemeral=True)
-        try:
-            match = await self._find_device(device)
-            await interaction.followup.send(f"**{match['name']}** uses identifier `{match['identifier']}`.", ephemeral=True)
-        except (ValueError, aiohttp.ClientError) as error:
-            await interaction.followup.send(str(error), ephemeral=True)
-
-    @tss.command(name="versions", description="List currently signed iOS versions for a device")
-    async def tss_versions(self, interaction: discord.Interaction, device: str):
-        await interaction.response.defer()
-        try:
-            match = await self._find_device(device)
-            data = await self._get_json(f"{IPSW_API}/device/{match['identifier']}?type=ipsw")
-            signed = [item.get("version") for item in data.get("firmwares", []) if item.get("signed")]
-            versions = list(dict.fromkeys(value for value in signed if value))
-            text = ", ".join(versions[:20]) or "No signed iOS versions were reported."
-            await interaction.followup.send(f"**TSS signing for {match['name']}**\n{text}")
-        except (ValueError, aiohttp.ClientError) as error:
-            await interaction.followup.send(str(error), ephemeral=True)
-
-    @tss.command(name="status", description="Check whether GIR's signing checker is ready")
-    async def tss_status(self, interaction: discord.Interaction):
-        installed = Path(TSSCHECKER).is_file()
-        await interaction.response.send_message(
-            "**Fast signing checks:** Ready\n"
-            "Interactive checks use the live firmware catalog and have a 25-second deadline. No IPSW is downloaded.\n"
-            f"**Local TSSChecker utility:** {'Installed (not used for interactive checks)' if installed else 'Not installed'}",
-            ephemeral=True,
-        )
-
-    @tss.command(name="help", description="Show examples of every TSS command")
-    async def tss_help(self, interaction: discord.Interaction):
-        await interaction.response.send_message(
-            "**TSS commands**\n"
-            "`/tss check device:iPhone 16 ios_version:18.0`\n"
-            "`/tss device device:iPhone 16`\n"
-            "`/tss versions device:iPhone 16`\n"
-            "`/tss status`",
-            ephemeral=True,
-        )
-
-    @apple.command(name="events", description="Open Apple's official event page")
-    async def apple_events(self, interaction: discord.Interaction):
-        await interaction.response.send_message(f"🍎 Apple event schedule and replays: {APPLE_EVENTS}")
-
-    @apple.command(name="latest", description="Open Apple's official Newsroom")
-    async def apple_latest(self, interaction: discord.Interaction):
-        await interaction.response.send_message(f"🍎 Apple Newsroom: {APPLE_NEWSROOM}")
-
-    @apple.command(name="developer", description="Open Apple's developer event schedule")
-    async def apple_developer(self, interaction: discord.Interaction):
-        await interaction.response.send_message("Apple developer sessions, labs, and events: https://developer.apple.com/events/")
 
 async def setup(bot):
     await bot.add_cog(ServerSuite(bot))

--- a/community_rules.py
+++ b/community_rules.py
@@ -1,0 +1,18 @@
+"""Pure detection helpers for the community suite."""
+import re
+
+
+INVITE_PATTERN = re.compile(r"(?:discord\.gg|discord(?:app)?\.com/invite)/[A-Za-z0-9-]+", re.I)
+
+
+def caps_percent(text: str) -> int:
+    letters = [char for char in text if char.isalpha()]
+    return round(100 * sum(char.isupper() for char in letters) / len(letters)) if letters else 0
+
+
+def has_invite(text: str) -> bool:
+    return bool(INVITE_PATTERN.search(text))
+
+
+def recent_count(timestamps: list[float], now: float, window_seconds: int) -> int:
+    return sum(now - stamp <= window_seconds for stamp in timestamps)

--- a/community_rules.py
+++ b/community_rules.py
@@ -3,6 +3,7 @@ import re
 
 
 INVITE_PATTERN = re.compile(r"(?:discord\.gg|discord(?:app)?\.com/invite)/[A-Za-z0-9-]+", re.I)
+IMAGE_EXTENSIONS = {".avif", ".gif", ".heic", ".heif", ".jpeg", ".jpg", ".png", ".webp"}
 
 
 def caps_percent(text: str) -> int:
@@ -16,3 +17,10 @@ def has_invite(text: str) -> bool:
 
 def recent_count(timestamps: list[float], now: float, window_seconds: int) -> int:
     return sum(now - stamp <= window_seconds for stamp in timestamps)
+
+
+def is_image_attachment(content_type, filename: str) -> bool:
+    """Recognize Discord image uploads even when their MIME type is unavailable."""
+    if content_type and content_type.casefold().startswith("image/"):
+        return True
+    return any(filename.casefold().endswith(extension) for extension in IMAGE_EXTENSIONS)

--- a/community_rules.py
+++ b/community_rules.py
@@ -1,9 +1,13 @@
 """Pure detection helpers for the community suite."""
 import re
+import unicodedata
 from typing import Optional
 
 
-INVITE_PATTERN = re.compile(r"(?:discord\.gg|discord(?:app)?\.com/invite)/[A-Za-z0-9-]+", re.I)
+INVITE_PATTERN = re.compile(
+    r"(?:discord\.gg/(?:invite/)?|discord(?:app)?\.com/invite/|(?:dsc|invite)\.gg/|discord\.(?:io|li|me|st)/)[A-Za-z0-9-]{2,}",
+    re.I,
+)
 IMAGE_EXTENSIONS = {".avif", ".gif", ".heic", ".heif", ".jpeg", ".jpg", ".png", ".webp"}
 URL_PATTERN = re.compile(r"(?:https?://|www\.)\S+", re.I)
 SCAM_BRANDS = re.compile(r"\b(mr\s*beast|discord|steam|paypal|cash\s*app|coinbase|apple|microsoft|xbox|playstation)\b", re.I)
@@ -16,7 +20,20 @@ INVISIBLE_CHARACTERS = re.compile(r"[\u00ad\u034f\u061c\u115f\u1160\u17b4\u17b5\
 
 
 def normalize_obfuscated_text(text: str) -> str:
-    return INVISIBLE_CHARACTERS.sub("", str(text or ""))
+    normalized = unicodedata.normalize("NFKC", str(text or ""))
+    return "".join(character for character in normalized
+                   if unicodedata.category(character) not in {"Cf", "Cc"})
+
+
+def has_hidden_invite(text: str) -> bool:
+    """Detect an invite that only appears after removing hiding characters."""
+    original = str(text or "")
+    return has_invite(normalize_obfuscated_text(original)) and not has_invite(original)
+
+
+def has_suspicious_image_name(filename: str) -> bool:
+    """Match the generic numbered image name used by a recurring compromise campaign."""
+    return bool(re.fullmatch(r"1\.[A-Za-z0-9]{1,10}", str(filename or "").casefold()))
 
 
 def caps_percent(text: str) -> int:

--- a/community_rules.py
+++ b/community_rules.py
@@ -10,11 +10,11 @@ INVITE_PATTERN = re.compile(
 )
 IMAGE_EXTENSIONS = {".avif", ".gif", ".heic", ".heif", ".jpeg", ".jpg", ".png", ".webp"}
 URL_PATTERN = re.compile(r"(?:https?://|www\.)\S+", re.I)
-SCAM_BRANDS = re.compile(r"\b(mr\s*beast|discord|steam|paypal|cash\s*app|coinbase|apple|microsoft|xbox|playstation)\b", re.I)
-SCAM_REWARDS = re.compile(r"\b(giveaway|winner|won|free\s+(?:nitro|gift|money|crypto)|airdrop|bonus|reward|claim|double\s+(?:your|my)|investment)\b", re.I)
+SCAM_BRANDS = re.compile(r"\b(mr\s*beast|steam|paypal|cash\s*app|coinbase|microsoft|xbox|playstation)\b", re.I)
+SCAM_REWARDS = re.compile(r"\b(giveaway|winner|won|free\s+(?:nitro|gift|money|crypto)|bonus|reward|claim|double\s+(?:your|my)|investment)\b", re.I)
 SCAM_ACTIONS = re.compile(r"\b(click|verify|connect|scan|deposit|send|withdraw|activate|sign\s*in|login|dm\s+me|message\s+me)\b", re.I)
 SCAM_URGENCY = re.compile(r"\b(now|today only|limited time|act fast|expires?|within\s+\d+\s*(?:minutes?|hours?))\b", re.I)
-SCAM_SECRETS = re.compile(r"\b(seed phrase|recovery phrase|private key|wallet phrase|password|qr code)\b", re.I)
+SCAM_SECRETS = re.compile(r"\b(seed phrase|recovery phrase|private key|wallet phrase)\b", re.I)
 SUSPICIOUS_HOST = re.compile(r"(?:xn--|bit\.ly|tinyurl\.com|t\.co|discord(?:-|\.)?gift|disc[o0]rd|ste[a4]m|mrbeast)[^\s/]*", re.I)
 INVISIBLE_CHARACTERS = re.compile(r"[\u00ad\u034f\u061c\u115f\u1160\u17b4\u17b5\u180b-\u180f\u200b-\u200f\u202a-\u202e\u2060-\u206f\ufeff\uffa0]")
 

--- a/community_rules.py
+++ b/community_rules.py
@@ -12,6 +12,11 @@ SCAM_ACTIONS = re.compile(r"\b(click|verify|connect|scan|deposit|send|withdraw|a
 SCAM_URGENCY = re.compile(r"\b(now|today only|limited time|act fast|expires?|within\s+\d+\s*(?:minutes?|hours?))\b", re.I)
 SCAM_SECRETS = re.compile(r"\b(seed phrase|recovery phrase|private key|wallet phrase|password|qr code)\b", re.I)
 SUSPICIOUS_HOST = re.compile(r"(?:xn--|bit\.ly|tinyurl\.com|t\.co|discord(?:-|\.)?gift|disc[o0]rd|ste[a4]m|mrbeast)[^\s/]*", re.I)
+INVISIBLE_CHARACTERS = re.compile(r"[\u00ad\u034f\u061c\u115f\u1160\u17b4\u17b5\u180b-\u180f\u200b-\u200f\u202a-\u202e\u2060-\u206f\ufeff\uffa0]")
+
+
+def normalize_obfuscated_text(text: str) -> str:
+    return INVISIBLE_CHARACTERS.sub("", str(text or ""))
 
 
 def caps_percent(text: str) -> int:
@@ -36,7 +41,7 @@ def is_image_attachment(content_type, filename: str) -> bool:
 
 def detect_scam(text: str) -> Optional[str]:
     """Return a plain-language reason when several independent scam signals agree."""
-    normalized = " ".join(str(text or "").split())
+    normalized = " ".join(normalize_obfuscated_text(text).split())
     if not normalized:
         return None
     has_url = bool(URL_PATTERN.search(normalized))

--- a/community_rules.py
+++ b/community_rules.py
@@ -1,9 +1,17 @@
 """Pure detection helpers for the community suite."""
 import re
+from typing import Optional
 
 
 INVITE_PATTERN = re.compile(r"(?:discord\.gg|discord(?:app)?\.com/invite)/[A-Za-z0-9-]+", re.I)
 IMAGE_EXTENSIONS = {".avif", ".gif", ".heic", ".heif", ".jpeg", ".jpg", ".png", ".webp"}
+URL_PATTERN = re.compile(r"(?:https?://|www\.)\S+", re.I)
+SCAM_BRANDS = re.compile(r"\b(mr\s*beast|discord|steam|paypal|cash\s*app|coinbase|apple|microsoft|xbox|playstation)\b", re.I)
+SCAM_REWARDS = re.compile(r"\b(giveaway|winner|won|free\s+(?:nitro|gift|money|crypto)|airdrop|bonus|reward|claim|double\s+(?:your|my)|investment)\b", re.I)
+SCAM_ACTIONS = re.compile(r"\b(click|verify|connect|scan|deposit|send|withdraw|activate|sign\s*in|login|dm\s+me|message\s+me)\b", re.I)
+SCAM_URGENCY = re.compile(r"\b(now|today only|limited time|act fast|expires?|within\s+\d+\s*(?:minutes?|hours?))\b", re.I)
+SCAM_SECRETS = re.compile(r"\b(seed phrase|recovery phrase|private key|wallet phrase|password|qr code)\b", re.I)
+SUSPICIOUS_HOST = re.compile(r"(?:xn--|bit\.ly|tinyurl\.com|t\.co|discord(?:-|\.)?gift|disc[o0]rd|ste[a4]m|mrbeast)[^\s/]*", re.I)
 
 
 def caps_percent(text: str) -> int:
@@ -24,3 +32,30 @@ def is_image_attachment(content_type, filename: str) -> bool:
     if content_type and content_type.casefold().startswith("image/"):
         return True
     return any(filename.casefold().endswith(extension) for extension in IMAGE_EXTENSIONS)
+
+
+def detect_scam(text: str) -> Optional[str]:
+    """Return a plain-language reason when several independent scam signals agree."""
+    normalized = " ".join(str(text or "").split())
+    if not normalized:
+        return None
+    has_url = bool(URL_PATTERN.search(normalized))
+    brand = SCAM_BRANDS.search(normalized)
+    reward = SCAM_REWARDS.search(normalized)
+    action = SCAM_ACTIONS.search(normalized)
+    urgency = SCAM_URGENCY.search(normalized)
+    secret = SCAM_SECRETS.search(normalized)
+    suspicious_host = SUSPICIOUS_HOST.search(normalized) if has_url else None
+    score = sum((bool(brand), bool(reward), bool(action), bool(urgency), bool(secret) * 2,
+                 bool(suspicious_host) * 2, has_url))
+    # Requiring multiple independent signals prevents ordinary discussion such as
+    # "I saw a MrBeast scam" from being moderated.
+    if score < 4 or not (has_url or secret):
+        return None
+    if brand and re.search(r"mr\s*beast", brand.group(), re.I):
+        return "possible fake MrBeast giveaway"
+    if secret:
+        return "possible credential or wallet theft"
+    if reward:
+        return "possible fake giveaway or reward"
+    return "possible phishing link"

--- a/data/model/__init__.py
+++ b/data/model/__init__.py
@@ -5,3 +5,4 @@ from .giveaway import *
 from .guild import *
 from .tag import *
 from .user import *
+from .identity_history import *

--- a/data/model/identity_history.py
+++ b/data/model/identity_history.py
@@ -1,0 +1,18 @@
+import mongoengine
+from datetime import datetime
+
+
+class IdentityHistory(mongoengine.Document):
+    _id = mongoengine.LongField(required=True, primary_key=True)
+    usernames = mongoengine.ListField(mongoengine.StringField(), default=[])
+    display_names = mongoengine.ListField(mongoengine.StringField(), default=[])
+    avatar_hashes = mongoengine.ListField(mongoengine.StringField(), default=[])
+    role_ids = mongoengine.ListField(mongoengine.LongField(), default=[])
+    account_created = mongoengine.DateTimeField()
+    last_joined = mongoengine.DateTimeField()
+    first_seen = mongoengine.DateTimeField(default=datetime.utcnow)
+    last_seen = mongoengine.DateTimeField(default=datetime.utcnow)
+    status = mongoengine.StringField(default="member")
+    observations = mongoengine.IntField(default=0)
+
+    meta = {"db_alias": "default", "collection": "identity_history", "indexes": ["usernames", "display_names", "avatar_hashes", "last_seen"]}

--- a/data/services/guild_service.py
+++ b/data/services/guild_service.py
@@ -105,7 +105,7 @@ class GuildService:
         await self.get_raid_phrases.cache.clear()
         return True
     
-    @cached(ttl=3600, key="guild_raid_phrases")
+    @cached(ttl=30, key="guild_raid_phrases")
     async def get_raid_phrases(self):
         return self.get_guild().raid_phrases
 
@@ -125,7 +125,7 @@ class GuildService:
         await self.get_filtered_words.cache.clear()
         return True
 
-    @cached(ttl=3600, key="guild_filtered_words")
+    @cached(ttl=30, key="guild_filtered_words")
     async def get_filtered_words(self) -> FilterWord:
         return self.get_guild().filter_words
 

--- a/data/services/guild_service.py
+++ b/data/services/guild_service.py
@@ -105,7 +105,7 @@ class GuildService:
         await self.get_raid_phrases.cache.clear()
         return True
     
-    @cached(ttl=30, key="guild_raid_phrases")
+    @cached(ttl=3600, key="guild_raid_phrases")
     async def get_raid_phrases(self):
         return self.get_guild().raid_phrases
 
@@ -125,7 +125,7 @@ class GuildService:
         await self.get_filtered_words.cache.clear()
         return True
 
-    @cached(ttl=30, key="guild_filtered_words")
+    @cached(ttl=3600, key="guild_filtered_words")
     async def get_filtered_words(self) -> FilterWord:
         return self.get_guild().filter_words
 

--- a/extensions.py
+++ b/extensions.py
@@ -6,6 +6,7 @@ from pathlib import Path
 # utility, logging, XP, and self-service features that make sense in any Discord
 # server. The original jailbreak/news integrations remain available explicitly.
 default_extensions = [
+    "cogs.community_suite",
     "cogs.commands.info.stats",
     "cogs.commands.info.help",
     "cogs.commands.info.tags",

--- a/extensions.py
+++ b/extensions.py
@@ -8,6 +8,7 @@ from pathlib import Path
 default_extensions = [
     "cogs.community_suite",
     "cogs.server_suite",
+    "cogs.music_suite",
     "cogs.commands.info.stats",
     "cogs.commands.info.help",
     "cogs.commands.info.tags",

--- a/extensions.py
+++ b/extensions.py
@@ -28,7 +28,7 @@ default_extensions = [
 ]
 
 feature_file = Path(os.environ.get(
-    "GIR_FEATURE_FILE", "/Volumes/4TB/Services/GIR/dashboard/data/features.json"))
+    "GIR_FEATURE_FILE", str(Path.home() / "Library/Application Support/SowensServer/GIRRuntime/dashboard/data/features.json")))
 try:
     enabled_extensions = set(json.loads(feature_file.read_text()).get("enabled", []))
     initial_extensions = [name for name in default_extensions if name in enabled_extensions]

--- a/extensions.py
+++ b/extensions.py
@@ -7,6 +7,7 @@ from pathlib import Path
 # server. The original jailbreak/news integrations remain available explicitly.
 default_extensions = [
     "cogs.community_suite",
+    "cogs.server_suite",
     "cogs.commands.info.stats",
     "cogs.commands.info.help",
     "cogs.commands.info.tags",

--- a/extensions.py
+++ b/extensions.py
@@ -1,15 +1,15 @@
+import os
+
+# The upstream bot was built for r/Jailbreak. Start with the general moderation,
+# utility, logging, XP, and self-service features that make sense in any Discord
+# server. The original jailbreak/news integrations remain available explicitly.
 initial_extensions = [
-    "cogs.commands.info.devices",
     "cogs.commands.info.stats",
     "cogs.commands.info.help",
     "cogs.commands.info.tags",
     "cogs.commands.info.userinfo",
     "cogs.commands.misc.admin",
-    "cogs.commands.misc.canister",
-    "cogs.commands.misc.genius_submod",
     "cogs.commands.misc.giveaway",
-    "cogs.commands.misc.ioscfw",
-    "cogs.commands.misc.memes",
     "cogs.commands.misc.misc",
     "cogs.commands.misc.timezones",
     "cogs.commands.mod.antiraid",
@@ -18,14 +18,23 @@ initial_extensions = [
     "cogs.commands.mod.modutils",
     "cogs.monitors.misc.boosteremojis",
     "cogs.monitors.misc.fixsocials",
-    "cogs.monitors.misc.songs",
     "cogs.monitors.mod.antiraid",
     "cogs.monitors.mod.logging",
     "cogs.monitors.mod.filter",
-    "cogs.monitors.mod.sabbath",
-    "cogs.monitors.mod.unban_appeals",
-    "cogs.monitors.utils.applenews",
     "cogs.monitors.utils.birthday",
-    "cogs.monitors.utils.jailbreak_monitors",
     "cogs.monitors.utils.xp",
 ]
+
+if os.environ.get("GIR_LEGACY_JAILBREAK_FEATURES") == "True":
+    initial_extensions += [
+        "cogs.commands.info.devices",
+        "cogs.commands.misc.canister",
+        "cogs.commands.misc.genius_submod",
+        "cogs.commands.misc.ioscfw",
+        "cogs.commands.misc.memes",
+        "cogs.monitors.misc.songs",
+        "cogs.monitors.mod.sabbath",
+        "cogs.monitors.mod.unban_appeals",
+        "cogs.monitors.utils.applenews",
+        "cogs.monitors.utils.jailbreak_monitors",
+    ]

--- a/extensions.py
+++ b/extensions.py
@@ -1,9 +1,11 @@
+import json
 import os
+from pathlib import Path
 
 # The upstream bot was built for r/Jailbreak. Start with the general moderation,
 # utility, logging, XP, and self-service features that make sense in any Discord
 # server. The original jailbreak/news integrations remain available explicitly.
-initial_extensions = [
+default_extensions = [
     "cogs.commands.info.stats",
     "cogs.commands.info.help",
     "cogs.commands.info.tags",
@@ -24,6 +26,14 @@ initial_extensions = [
     "cogs.monitors.utils.birthday",
     "cogs.monitors.utils.xp",
 ]
+
+feature_file = Path(os.environ.get(
+    "GIR_FEATURE_FILE", "/Volumes/4TB/Services/GIR/dashboard/data/features.json"))
+try:
+    enabled_extensions = set(json.loads(feature_file.read_text()).get("enabled", []))
+    initial_extensions = [name for name in default_extensions if name in enabled_extensions]
+except (OSError, ValueError, TypeError):
+    initial_extensions = list(default_extensions)
 
 if os.environ.get("GIR_LEGACY_JAILBREAK_FEATURES") == "True":
     initial_extensions += [

--- a/extensions.py
+++ b/extensions.py
@@ -1,6 +1,7 @@
 import json
 import os
 from pathlib import Path
+from utils.runtime_paths import runtime_data_file
 
 # The upstream bot was built for r/Jailbreak. Start with the general moderation,
 # utility, logging, XP, and self-service features that make sense in any Discord
@@ -30,8 +31,7 @@ default_extensions = [
     "cogs.monitors.utils.xp",
 ]
 
-feature_file = Path(os.environ.get(
-    "GIR_FEATURE_FILE", str(Path.home() / "Library/Application Support/SowensServer/GIRRuntime/dashboard/data/features.json")))
+feature_file = Path(os.environ.get("GIR_FEATURE_FILE", runtime_data_file("features.json")))
 try:
     enabled_extensions = set(json.loads(feature_file.read_text()).get("enabled", []))
     initial_extensions = [name for name in default_extensions if name in enabled_extensions]

--- a/main.py
+++ b/main.py
@@ -22,7 +22,13 @@ import warnings
 warnings.simplefilter(action='ignore', category=FutureWarning)
 
 
-intents = discord.Intents.all()
+# Keep the events GIR uses while avoiding presence and typing firehoses on very
+# large servers. Member and message-content access are checked by the dashboard.
+intents = discord.Intents.default()
+intents.members = True
+intents.message_content = True
+intents.presences = False
+intents.typing = False
 mentions = discord.AllowedMentions(everyone=False, users=True, roles=False)
 
 
@@ -121,7 +127,8 @@ class MyTree(app_commands.CommandTree):
         return True
 
 
-bot = Bot(command_prefix='!', intents=intents, allowed_mentions=mentions, tree_cls=MyTree)
+bot = Bot(command_prefix='!', intents=intents, allowed_mentions=mentions, tree_cls=MyTree,
+          chunk_guilds_at_startup=False, max_messages=5000)
 
 @bot.tree.error
 async def app_command_error(interaction: discord.Interaction, error: AppCommandError):

--- a/main.py
+++ b/main.py
@@ -83,11 +83,12 @@ class Bot(commands.Bot):
 
         guild = discord.Object(id=cfg.guild_id)
         available = self.tree.get_commands(guild=guild)
+        command_type = lambda command: getattr(command, "type", discord.AppCommandType.chat_input)
         save_command_catalog([
             {
                 "name": command.name,
                 "description": getattr(command, "description", None) or "Right-click menu command",
-                "type": int(command.type.value),
+                "type": int(command_type(command).value),
                 "default_member_permissions": str(getattr(getattr(command, "default_permissions", None), "value", 0) or 0),
             }
             for command in available
@@ -95,7 +96,7 @@ class Bot(commands.Bot):
         disabled = command_selection()
         for command in available:
             if command.name in disabled:
-                self.tree.remove_command(command.name, guild=guild, type=command.type)
+                self.tree.remove_command(command.name, guild=guild, type=command_type(command))
 
         # Keep slash commands current without requiring the owner to run !sync
         # after an update. GIR's commands are guild-scoped, so this takes effect

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ import asyncio
 import os
 import traceback
 import json
+import uuid
 from pathlib import Path
 import discord
 from discord.ext import commands
@@ -130,7 +131,17 @@ async def app_command_error(interaction: discord.Interaction, error: AppCommandE
         error = error.original
 
     if isinstance(error, discord.errors.NotFound):
-        await ctx.channel.send(embed=discord.Embed(color=discord.Color.red(), title=":(\nYour command ran into a problem.", description=f"Sorry {interaction.user.mention}, it looks like I took too long to respond to you! If I didn't do what you wanted in time, please try again."), delete_after=7)
+        try:
+            await ctx.send_error("Discord says this command took too long. Please try it once more.", whisper=True)
+        except discord.HTTPException:
+            pass
+        return
+
+    if isinstance(error, discord.Forbidden):
+        logger.error(f"Discord denied command {getattr(interaction.command, 'qualified_name', 'unknown')}: {error}")
+        await ctx.send_error(
+            "Discord blocked that action. GIR has its moderation permission, but its role may be below the selected member's role. Ask the server owner to move GIR higher in Server Settings → Roles.",
+            followup=True, whisper=True)
         return
 
     if (isinstance(error, commands.MissingRequiredArgument)
@@ -144,19 +155,14 @@ async def app_command_error(interaction: discord.Interaction, error: AppCommandE
             or isinstance(error, commands.NoPrivateMessage)):
         await ctx.send_error(error, followup=True, whisper=True, delete_after=5)
     else:
+        reference = uuid.uuid4().hex[:8]
+        logger.error(f"Command error reference {reference}\n{''.join(traceback.format_exception(type(error), error, error.__traceback__))}")
         try:
-            raise error
-        except:
-            tb = traceback.format_exc()
-            logger.error(tb)
-            if len(tb.split('\n')) > 8:
-                tb = '\n'.join(tb.split('\n')[-8:])
-
-            tb_formatted = tb
-            if len(tb_formatted) > 1000:
-                tb_formatted = "...\n" + tb_formatted[-1000:]
-
-            await ctx.send_error(description=f"`{error}`\n```{tb_formatted}```", followup=True, whisper=True, delete_after=5)
+            await ctx.send_error(
+                description=f"Something unexpected happened. The private server log has reference `{reference}`.",
+                followup=True, whisper=True)
+        except discord.HTTPException:
+            logger.error(f"Could not deliver command error reference {reference} to Discord")
 
 
 @bot.event

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ import os
 import traceback
 import json
 import uuid
+import tempfile
 from pathlib import Path
 import discord
 from discord.ext import commands
@@ -32,6 +33,35 @@ intents.typing = False
 mentions = discord.AllowedMentions(everyone=False, users=True, roles=False)
 
 
+def command_settings_path() -> Path:
+    return Path(os.environ.get(
+        "GIR_COMMUNITY_FILE",
+        str(Path.home() / "Library/Application Support/SowensServer/GIRRuntime/dashboard/data/community.json"),
+    ))
+
+
+def command_selection() -> set[str]:
+    try:
+        return set(json.loads(command_settings_path().read_text()).get("disabledCommands", []))
+    except (OSError, ValueError, TypeError):
+        return set()
+
+
+def save_command_catalog(rows: list[dict]) -> None:
+    path = command_settings_path().with_name("command-catalog.json")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    handle, temporary = tempfile.mkstemp(prefix="command-catalog.", dir=path.parent)
+    try:
+        with os.fdopen(handle, "w") as stream:
+            json.dump({"commands": rows}, stream, indent=2, sort_keys=True)
+            stream.write("\n")
+        os.chmod(temporary, 0o600)
+        os.replace(temporary, path)
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+
+
 class Bot(commands.Bot):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -51,11 +81,27 @@ class Bot(commands.Bot):
 
         setup_context_commands(self)
 
+        guild = discord.Object(id=cfg.guild_id)
+        available = self.tree.get_commands(guild=guild)
+        save_command_catalog([
+            {
+                "name": command.name,
+                "description": getattr(command, "description", None) or "Right-click menu command",
+                "type": int(command.type.value),
+                "default_member_permissions": str(getattr(getattr(command, "default_permissions", None), "value", 0) or 0),
+            }
+            for command in available
+        ])
+        disabled = command_selection()
+        for command in available:
+            if command.name in disabled:
+                self.tree.remove_command(command.name, guild=guild, type=command.type)
+
         # Keep slash commands current without requiring the owner to run !sync
         # after an update. GIR's commands are guild-scoped, so this takes effect
         # immediately in the configured server.
         if os.environ.get("GIR_SYNC_COMMANDS", "True") == "True":
-            synced = await self.tree.sync(guild=discord.Object(id=cfg.guild_id))
+            synced = await self.tree.sync(guild=guild)
             logger.info(f"Synced {len(synced)} application commands.")
 
         self.tasks = Tasks(self)
@@ -74,11 +120,7 @@ class MyTree(app_commands.CommandTree):
 
         if command is not None:
             root_name = command.root_parent.name if command.root_parent else command.name
-            settings_path = Path(os.environ.get("GIR_COMMUNITY_FILE", str(Path.home() / "Library/Application Support/SowensServer/GIRRuntime/dashboard/data/community.json")))
-            try:
-                disabled = set(json.loads(settings_path.read_text()).get("disabledCommands", []))
-            except (OSError, ValueError, TypeError):
-                disabled = set()
+            disabled = command_selection()
             if root_name in disabled and interaction.user.id != cfg.owner_id:
                 await interaction.response.send_message("That command is currently turned off for this server.", ephemeral=True)
                 return False

--- a/main.py
+++ b/main.py
@@ -1,6 +1,8 @@
 import asyncio
 import os
 import traceback
+import json
+from pathlib import Path
 import discord
 from discord.ext import commands
 from discord import app_commands
@@ -61,10 +63,21 @@ class MyTree(app_commands.CommandTree):
         if interaction.user.bot:
             return False
 
+        command = interaction.command
+
+        if command is not None:
+            root_name = command.root_parent.name if command.root_parent else command.name
+            settings_path = Path(os.environ.get("GIR_COMMUNITY_FILE", str(Path.home() / "Library/Application Support/SowensServer/GIRRuntime/dashboard/data/community.json")))
+            try:
+                disabled = set(json.loads(settings_path.read_text()).get("disabledCommands", []))
+            except (OSError, ValueError, TypeError):
+                disabled = set()
+            if root_name in disabled and interaction.user.id != cfg.owner_id:
+                await interaction.response.send_message("That command is currently turned off for this server.", ephemeral=True)
+                return False
+
         if gatekeeper.has(interaction.user.guild, interaction.user, 6):
             return True
-
-        command = interaction.command
 
         if isinstance(interaction.command, discord.app_commands.ContextMenu):
             return True

--- a/main.py
+++ b/main.py
@@ -42,6 +42,13 @@ class Bot(commands.Bot):
 
         setup_context_commands(self)
 
+        # Keep slash commands current without requiring the owner to run !sync
+        # after an update. GIR's commands are guild-scoped, so this takes effect
+        # immediately in the configured server.
+        if os.environ.get("GIR_SYNC_COMMANDS", "True") == "True":
+            synced = await self.tree.sync(guild=discord.Object(id=cfg.guild_id))
+            logger.info(f"Synced {len(synced)} application commands.")
+
         self.tasks = Tasks(self)
         await init_client_session()
 
@@ -166,4 +173,5 @@ async def main():
     async with bot:
         await bot.start(os.environ.get("GIR_TOKEN"), reconnect=True)
 
-asyncio.run(main())
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/main.py
+++ b/main.py
@@ -16,6 +16,7 @@ from cogs.commands.context_commands import setup_context_commands
 
 from typing import Union
 from data.services.user_service import user_service
+from utils.runtime_paths import runtime_data_file
 
 # Remove warning from songs cog
 import warnings
@@ -34,10 +35,7 @@ mentions = discord.AllowedMentions(everyone=False, users=True, roles=False)
 
 
 def command_settings_path() -> Path:
-    return Path(os.environ.get(
-        "GIR_COMMUNITY_FILE",
-        str(Path.home() / "Library/Application Support/SowensServer/GIRRuntime/dashboard/data/community.json"),
-    ))
+    return Path(os.environ.get("GIR_COMMUNITY_FILE", runtime_data_file("community.json")))
 
 
 def command_selection() -> set[str]:

--- a/tests/test_command_registry.py
+++ b/tests/test_command_registry.py
@@ -1,0 +1,49 @@
+import ast
+import unittest
+from collections import Counter
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def slash_command_names():
+    names = []
+    for source in (ROOT / "cogs").rglob("*.py"):
+        if source.name.startswith("._"):
+            continue
+        tree = ast.parse(source.read_text(encoding="utf-8"), filename=str(source))
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            for decorator in node.decorator_list:
+                if not isinstance(decorator, ast.Call) or not isinstance(decorator.func, ast.Attribute):
+                    continue
+                owner = decorator.func.value
+                if not (isinstance(owner, ast.Name) and owner.id == "app_commands" and decorator.func.attr == "command"):
+                    continue
+                explicit_name = next(
+                    (kw.value.value for kw in decorator.keywords if kw.arg == "name" and isinstance(kw.value, ast.Constant)),
+                    None,
+                )
+                names.append(explicit_name or node.name)
+    return names
+
+
+class CommandRegistryTests(unittest.TestCase):
+    def test_top_level_slash_names_are_unique(self):
+        names = slash_command_names()
+        duplicates = sorted(name for name, count in Counter(names).items() if count > 1)
+        self.assertEqual(duplicates, [])
+
+    def test_overlapping_commands_are_consolidated(self):
+        names = set(slash_command_names())
+        self.assertTrue({"avatar", "serverinfo", "announce", "kick"}.issubset(names))
+        self.assertTrue({"pfp", "membercount", "embed", "roblox"}.isdisjoint(names))
+
+    def test_registry_stays_below_discord_limit(self):
+        self.assertLessEqual(len(slash_command_names()), 100)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_command_registry.py
+++ b/tests/test_command_registry.py
@@ -38,8 +38,8 @@ class CommandRegistryTests(unittest.TestCase):
 
     def test_overlapping_commands_are_consolidated(self):
         names = set(slash_command_names())
-        self.assertTrue({"avatar", "serverinfo", "announce", "kick"}.issubset(names))
-        self.assertTrue({"pfp", "membercount", "embed", "roblox"}.isdisjoint(names))
+        self.assertTrue({"avatar", "serverinfo", "announce", "kick", "roblox"}.issubset(names))
+        self.assertTrue({"pfp", "membercount", "embed"}.isdisjoint(names))
 
     def test_registry_stays_below_discord_limit(self):
         self.assertLessEqual(len(slash_command_names()), 100)

--- a/tests/test_community_rules.py
+++ b/tests/test_community_rules.py
@@ -1,6 +1,8 @@
 import unittest
 
-from community_rules import caps_percent, detect_scam, has_invite, is_image_attachment, normalize_obfuscated_text, recent_count
+from community_rules import (caps_percent, detect_scam, has_hidden_invite, has_invite,
+                             has_suspicious_image_name, is_image_attachment,
+                             normalize_obfuscated_text, recent_count)
 
 
 def test_detects_fake_mrbeast_giveaway():
@@ -20,6 +22,12 @@ def test_removes_invisible_invite_bypass_characters():
     hidden = "https://disc\u200bord.\u200bgg/example"
     assert normalize_obfuscated_text(hidden) == "https://discord.gg/example"
     assert has_invite(normalize_obfuscated_text(hidden))
+    assert has_hidden_invite(hidden)
+    assert not has_hidden_invite("https://discord.gg/example")
+
+
+def test_normalizes_compatibility_characters_and_control_codes():
+    assert normalize_obfuscated_text("ｄｉｓｃｏｒｄ．ｇｇ/ab\u202ec") == "discord.gg/abc"
 
 
 class CommunityRuleTests(unittest.TestCase):
@@ -32,6 +40,13 @@ class CommunityRuleTests(unittest.TestCase):
         self.assertTrue(has_invite("DISCORD.COM/invite/example"))
         self.assertFalse(has_invite("https://example.com"))
 
+    def test_hidden_invites_and_compatibility_characters_are_detected(self):
+        hidden = "https://disc\u200bord.\u200bgg/example"
+        self.assertTrue(has_hidden_invite(hidden))
+        self.assertFalse(has_hidden_invite("https://discord.gg/example"))
+        self.assertEqual(normalize_obfuscated_text("ｄｉｓｃｏｒｄ．ｇｇ/ab\u202ec"),
+                         "discord.gg/abc")
+
     def test_only_events_inside_window_count(self):
         self.assertEqual(recent_count([80, 91, 95, 100], 100, 10), 3)
 
@@ -39,6 +54,12 @@ class CommunityRuleTests(unittest.TestCase):
         self.assertTrue(is_image_attachment("image/png", "upload.bin"))
         self.assertTrue(is_image_attachment(None, "Screenshot.HEIC"))
         self.assertFalse(is_image_attachment("application/pdf", "statement.pdf"))
+
+    def test_suspicious_campaign_image_filename_is_narrow(self):
+        self.assertTrue(has_suspicious_image_name("1.png"))
+        self.assertTrue(has_suspicious_image_name("1.HEIC"))
+        self.assertFalse(has_suspicious_image_name("10.png"))
+        self.assertFalse(has_suspicious_image_name("photo1.png"))
 
 
 if __name__ == "__main__":

--- a/tests/test_community_rules.py
+++ b/tests/test_community_rules.py
@@ -1,0 +1,21 @@
+import unittest
+
+from community_rules import caps_percent, has_invite, recent_count
+
+
+class CommunityRuleTests(unittest.TestCase):
+    def test_caps_ignores_numbers_and_punctuation(self):
+        self.assertEqual(caps_percent("THIS is 123!"), 67)
+        self.assertEqual(caps_percent("123!"), 0)
+
+    def test_discord_invites_are_detected(self):
+        self.assertTrue(has_invite("join https://discord.gg/example"))
+        self.assertTrue(has_invite("DISCORD.COM/invite/example"))
+        self.assertFalse(has_invite("https://example.com"))
+
+    def test_only_events_inside_window_count(self):
+        self.assertEqual(recent_count([80, 91, 95, 100], 100, 10), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_community_rules.py
+++ b/tests/test_community_rules.py
@@ -1,6 +1,19 @@
 import unittest
 
-from community_rules import caps_percent, has_invite, is_image_attachment, recent_count
+from community_rules import caps_percent, detect_scam, has_invite, is_image_attachment, recent_count
+
+
+def test_detects_fake_mrbeast_giveaway():
+    assert detect_scam("MrBeast giveaway winner! Claim now at https://mrbeast-gift.example") == "possible fake MrBeast giveaway"
+
+
+def test_detects_wallet_secret_theft():
+    assert detect_scam("Verify your wallet seed phrase now at https://bit.ly/example") == "possible credential or wallet theft"
+
+
+def test_does_not_flag_normal_scam_discussion():
+    assert detect_scam("I saw a video explaining the MrBeast scam yesterday") is None
+    assert detect_scam("Steam has a giveaway on its official store") is None
 
 
 class CommunityRuleTests(unittest.TestCase):

--- a/tests/test_community_rules.py
+++ b/tests/test_community_rules.py
@@ -1,6 +1,6 @@
 import unittest
 
-from community_rules import caps_percent, has_invite, recent_count
+from community_rules import caps_percent, has_invite, is_image_attachment, recent_count
 
 
 class CommunityRuleTests(unittest.TestCase):
@@ -15,6 +15,11 @@ class CommunityRuleTests(unittest.TestCase):
 
     def test_only_events_inside_window_count(self):
         self.assertEqual(recent_count([80, 91, 95, 100], 100, 10), 3)
+
+    def test_image_attachment_recognizes_mime_and_filename_fallback(self):
+        self.assertTrue(is_image_attachment("image/png", "upload.bin"))
+        self.assertTrue(is_image_attachment(None, "Screenshot.HEIC"))
+        self.assertFalse(is_image_attachment("application/pdf", "statement.pdf"))
 
 
 if __name__ == "__main__":

--- a/tests/test_community_rules.py
+++ b/tests/test_community_rules.py
@@ -1,6 +1,6 @@
 import unittest
 
-from community_rules import caps_percent, detect_scam, has_invite, is_image_attachment, recent_count
+from community_rules import caps_percent, detect_scam, has_invite, is_image_attachment, normalize_obfuscated_text, recent_count
 
 
 def test_detects_fake_mrbeast_giveaway():
@@ -14,6 +14,12 @@ def test_detects_wallet_secret_theft():
 def test_does_not_flag_normal_scam_discussion():
     assert detect_scam("I saw a video explaining the MrBeast scam yesterday") is None
     assert detect_scam("Steam has a giveaway on its official store") is None
+
+
+def test_removes_invisible_invite_bypass_characters():
+    hidden = "https://disc\u200bord.\u200bgg/example"
+    assert normalize_obfuscated_text(hidden) == "https://discord.gg/example"
+    assert has_invite(normalize_obfuscated_text(hidden))
 
 
 class CommunityRuleTests(unittest.TestCase):

--- a/tests/test_community_rules.py
+++ b/tests/test_community_rules.py
@@ -16,6 +16,8 @@ def test_detects_wallet_secret_theft():
 def test_does_not_flag_normal_scam_discussion():
     assert detect_scam("I saw a video explaining the MrBeast scam yesterday") is None
     assert detect_scam("Steam has a giveaway on its official store") is None
+    assert detect_scam("Change your Discord password and scan the QR code in Settings") is None
+    assert detect_scam("Use AirDrop to send this from your Apple device") is None
 
 
 def test_removes_invisible_invite_bypass_characters():

--- a/utils/config.py
+++ b/utils/config.py
@@ -23,6 +23,10 @@ class Roles:
     aaron_role: int
     new_member: int
 
+    def __getattr__(self, key):
+        # Optional, server-specific mappings may be removed in the dashboard.
+        return None
+
     def __getitem__(self, key):
         return getattr(self, key)
 
@@ -40,6 +44,10 @@ class Channels:
     private_logs: int
     public_logs: int
     rules: int
+
+    def __getattr__(self, key):
+        # Features already treat an unmapped channel as disabled.
+        return None
     reports: int
     sub_news: int
     rules: int

--- a/utils/config.py
+++ b/utils/config.py
@@ -112,8 +112,11 @@ class Config:
         self.spotify_secret = os.environ.get("SPOTIFY_SECRET")
         self.spotify_playlist_url = os.environ.get("SPOTIFY_PLAYLIST_URL")
         self.spotify_auth_code = os.environ.get("SPOTIFY_AUTH_CODE")
+        self.lastfm_api_key = os.environ.get("LASTFM_API_KEY")
         if self.spotify_id is None or self.spotify_secret is None or self.spotify_playlist_url is None:
             logger.warning("Adding songs to public Spotify playlist disabled.")
+        if self.lastfm_api_key is None:
+            logger.warning("Last.fm commands are installed but need LASTFM_API_KEY to return listening history.")
 
         self.roles = Roles()
         self.channels = Channels()

--- a/utils/config.py
+++ b/utils/config.py
@@ -112,11 +112,8 @@ class Config:
         self.spotify_secret = os.environ.get("SPOTIFY_SECRET")
         self.spotify_playlist_url = os.environ.get("SPOTIFY_PLAYLIST_URL")
         self.spotify_auth_code = os.environ.get("SPOTIFY_AUTH_CODE")
-        self.lastfm_api_key = os.environ.get("LASTFM_API_KEY")
         if self.spotify_id is None or self.spotify_secret is None or self.spotify_playlist_url is None:
             logger.warning("Adding songs to public Spotify playlist disabled.")
-        if self.lastfm_api_key is None:
-            logger.warning("Last.fm commands are installed but need LASTFM_API_KEY to return listening history.")
 
         self.roles = Roles()
         self.channels = Channels()

--- a/utils/context.py
+++ b/utils/context.py
@@ -214,7 +214,7 @@ class GIRContext:
 
         embed = discord.Embed(
             title=title, description=description,  color=discord.Color.red())
-        embed.set_footer(text="Note: The bot maintainer will be pinged about this error automatically.")
+        embed.set_footer(text="Technical details are kept in the private server log.")
         return await self.respond_or_edit(content="", embed=embed, ephemeral=self.whisper or whisper, view=discord.utils.MISSING, delete_after=delete_after, followup=followup)
 
     async def prompt(self, info: PromptData):

--- a/utils/framework/permissions.py
+++ b/utils/framework/permissions.py
@@ -28,22 +28,6 @@ class Permissions:
             
         """
 
-        roles_to_check = [
-            "member_plus",
-            "member_pro",
-            "member_edition",
-            "genius",
-            "moderator",
-            "administrator",
-        ]
-
-        for role in roles_to_check:
-            try:
-                getattr(cfg.roles, role)
-            except AttributeError:
-                raise AttributeError(
-                    f"Database is not set up properly! Role '{role}' is missing. Please refer to README.md.")
-
         self._permission_mapping = {
             1: cfg.roles.member_plus,
             2: cfg.roles.member_pro,
@@ -71,10 +55,10 @@ class Permissions:
                 and guild.get_role(cfg.roles.genius) in m.roles)),
 
             5: (lambda guild, m: self.has(guild, m, 6) or (guild.id == cfg.guild_id
-                and guild.get_role(cfg.roles.moderator) in m.roles)),
+                and (m.guild_permissions.manage_messages or self._has_mapped_role(m, "moderator")))),
 
             6: (lambda guild, m: self.has(guild, m, 7) or (guild.id == cfg.guild_id
-                and guild.get_role(cfg.roles.administrator) in m.roles)),
+                and (m.guild_permissions.administrator or self._has_mapped_role(m, "administrator")))),
 
             7: (lambda guild, m: self.has(guild, m, 9) or (guild.id == cfg.guild_id
                 and m == guild.owner)),
@@ -94,10 +78,19 @@ class Permissions:
             4: "Geniuses and up",
             5: "Moderators and up",
             6: "Administrators and up",
-            7: "Guild owner (Aaron) and up",
+            7: "Guild owner and up",
             9: "Bot owner",
             10: "Bot owner",
         }
+
+    @staticmethod
+    def _has_mapped_role(member: discord.Member, prefix: str) -> bool:
+        """Match the main role alias and any server-specific aliases."""
+        mapped = {
+            int(value) for key, value in vars(cfg.roles).items()
+            if (key == prefix or key.startswith(prefix + "_")) and str(value).isdigit()
+        }
+        return any(role.id in mapped for role in member.roles)
 
     @property
     def lowest_level(self) -> int:

--- a/utils/framework/transformers.py
+++ b/utils/framework/transformers.py
@@ -102,6 +102,14 @@ async def check_invokee(interaction: discord.Interaction, user: discord.Member):
         if user.id == interaction.client.user.id:
             raise PermissionsFailure("You can't call that on me :(")
 
+        if user.id == interaction.guild.owner_id:
+            raise PermissionsFailure("Discord does not allow bots to moderate the server owner.")
+
+        bot_member = interaction.guild.me
+        if bot_member is not None and user.top_role >= bot_member.top_role:
+            raise PermissionsFailure(
+                "Discord's role order blocks that action. In Server Settings → Roles, move GIR above this member's highest role.")
+
         if user:
             if user.top_role >= interaction.user.top_role:
                 raise PermissionsFailure(

--- a/utils/jobs.py
+++ b/utils/jobs.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import random
 from datetime import datetime, timedelta
@@ -53,7 +54,8 @@ class Tasks():
             }
 
         self.tasks = AsyncIOScheduler(
-            jobstores=jobstores, executors=executors, job_defaults=job_defaults, event_loop=bot.loop, timezone=utc)
+            jobstores=jobstores, executors=executors, job_defaults=job_defaults,
+            event_loop=asyncio.get_running_loop(), timezone=utc)
         self.tasks.start()
 
     def schedule_untimeout(self, _id: int, date: datetime) -> None:

--- a/utils/runtime_paths.py
+++ b/utils/runtime_paths.py
@@ -1,0 +1,10 @@
+"""Portable locations for dashboard-managed runtime files."""
+import os
+from pathlib import Path
+
+
+def runtime_data_file(filename: str) -> Path:
+    """Return a runtime data path, allowing deployments to override the directory."""
+    configured = os.environ.get("GIR_DATA_DIR")
+    directory = Path(configured).expanduser() if configured else Path.home() / ".gir" / "data"
+    return directory / filename

--- a/utils/views/confirm.py
+++ b/utils/views/confirm.py
@@ -45,6 +45,7 @@ class SecondStaffConfirm(ui.View):
         self.ctx = ctx
         self.value = None
         self.og_mod = og_mod
+        self.confirming_mod = None
 
     async def on_timeout(self) -> None:
         await self.ctx.send_warning("Timed out.")
@@ -59,6 +60,7 @@ class SecondStaffConfirm(ui.View):
     @ui.button(label='Yes', style=discord.ButtonStyle.success)
     async def confirm(self, interaction: discord.Interaction, _: ui.Button):
         self.ctx.interaction = interaction
+        self.confirming_mod = interaction.user
         self.value = True
         self.stop()
 


### PR DESCRIPTION
## Problem and resulting behavior

GIRRewrite is closely coupled to one server's static channels, roles, workflows, and manual command-sync process. This PR adds a configurable community layer while preserving GIR's database, permission model, moderation commands, and Discord.py extension layout.

## Current `main` compared with this PR

| Area | Current `main` | This PR |
| --- | --- | --- |
| Server configuration | Static mappings and source assumptions | Dashboard-managed community and feature files with portable runtime paths |
| Command deployment | Manual `!sync` | Optional guild-scoped automatic sync and dashboard command toggles |
| Discord limits | Commands removed from source | Full command catalog with an active set kept within Discord limits |
| Reports and moderation | Separate legacy paths | Report context action, configurable access and pings, evidence images, Ban/Dismiss controls, and trigger details |
| Scam handling | Existing filter sources | Unicode-normalized hidden invites, focused campaign patterns, and rate-limited grouped review |
| Member history | Current member records | Bounded Discord-ID identity history for names, roles, avatars, leave, and ban state |
| Channel behavior | Built-in assumptions | Monitored and ignored channels, threads, users, roles, and messages |
| Community tools | Existing GIR utilities | Welcome, autorole, starboard, suggestions, reaction roles, automatic replies, and engagement tools |
| Free games | No combined provider | Direct provider checks, filters, deduplication, and scheduled channel posts; no RSS |
| Music links | Legacy optional Spotify behavior | `/music link`, `/music search`, and optional channel link conversion |
| Validation | No focused suite for these additions | Command uniqueness/capacity and detection regression tests |

## Review changes

- Restored `/roblox` and its registry coverage.
- Staff-ban cases now record the second moderator who pressed **Yes**, while public logs continue to show the staff label.
- Replaced macOS-only paths with `GIR_DATA_DIR`, defaulting to `~/.gir/data` on all platforms. Individual file overrides remain available.
- Raised the default starboard threshold from three to five.
- Removed broad scam terms such as `discord`, `apple`, `airdrop`, `password`, and `qr code`; added false-positive tests for normal Apple-server discussion.
- Restored the raid-phrase and filtered-word cache TTLs to 3600 seconds. Mutation paths still clear their caches immediately.
- Removed redundant `/tss` and `/apple` groups. The existing AppleDB-backed `/firmware` implementation remains the source for firmware information.
- Removed GIR's Last.fm account/profile commands so the established Last.fm bot can keep handling scrobbles and leaderboards. Cross-service music links remain.
- Unexpected command failures are logged exactly once with a private reference ID and are not re-raised.
- Consolidated this work in PR #216; PR #215 is superseded.

## Major additions

- Four-image enforcement for members below the configured Member+ boundary.
- Report cards include reporter identity, direct message links, preserved evidence images, exact trigger details, and rate-aware Ban/Dismiss actions.
- Moderator and administrator ping options plus explicit reporter role/user access.
- Ignored users, roles, messages, channels, and threads.
- Multiple automatic text replies and emoji reactions per trigger.
- Dashboard editing and full lists for tags, filters, raid phrases, command selection, and other community settings.
- Persistent Discord identity history for cautious alt review.
- Free and discounted game monitoring through direct providers, with no RSS sources.
- Cross-service music discovery and links without storing a listening-service account.

## Configuration

Existing required values remain unchanged: `GIR_TOKEN`, `MAIN_GUILD_ID`, `OWNER_ID`, and MongoDB settings.

Optional additions:

- `GIR_DATA_DIR`: directory for runtime dashboard data; defaults to `~/.gir/data`.
- `GIR_COMMUNITY_FILE`: exact community settings file.
- `GIR_FEATURE_FILE`: exact enabled-extension file.
- `GIR_SYNC_COMMANDS=False`: disables automatic guild command sync.
- `GIR_LEGACY_JAILBREAK_FEATURES=True`: enables server-specific legacy monitors.

Feature and community files fall back safely when absent. Server Members and Message Content privileged intents must be enabled, and GIR's role must sit above roles it moderates.

## Validation

- `PYTHONPATH=. python3 -m unittest discover -s tests -v` — 9 tests passed.
- Python compilation passed for `cogs`, `community_rules.py`, `data`, `extensions.py`, `main.py`, and `utils`.
- `git diff --check` passed.
